### PR TITLE
feat: change le libellé d'activité "Transporteurs aériens utilisés à …

### DIFF
--- a/anssi-nis2-ui/src/References/LibellesActivites.ts
+++ b/anssi-nis2-ui/src/References/LibellesActivites.ts
@@ -269,5 +269,5 @@ export const libellesActivites: Record<ValeursActivites, string> = {
     "passagers et de fret, à l’exclusion des navires exploités à titre " +
     "individuel par ces sociétés",
   transporteursAeriensCommercial:
-    "Transporteurs aériens utilisés à des fins commerciales",
+    "Transporteurs aériens à des fins commerciales",
 };


### PR DESCRIPTION
…des fins commerciales"