### PR TITLE
Fix/erreur appel api email

### DIFF
--- a/anssi-nis2-api/.env.template
+++ b/anssi-nis2-api/.env.template
@@ -1,6 +1,16 @@
 # Port exposé pour l'API
 PORT=3000
 
+# Niveau de journalisation
+# Séparés entre ';' sans espace
+# error : erreur de Nest
+# warn : warning de Nest
+# verbose : details d'éxecution (niveau max pour du running)
+# debug : Informations de débugage spécifique (à désactiver en prod)
+# log : niveau par défaut
+# fatal : erreurs provoquant un crash de l'app
+NESTJS_LOG_LEVEL=
+
 # Bases de données
 # Base de donnée principale
 SCALINGO_POSTGRESQL_URL=

--- a/anssi-nis2-api/src/informations-emails/informations-emails.service.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { CreeInformationsEmailDto } from "./dto/cree-informations-email.dto";
 import { InformationsEmail } from "./entities/informations-email.entity";
 import { Repository } from "typeorm";
@@ -6,6 +6,8 @@ import { InjectRepository } from "@nestjs/typeorm";
 
 @Injectable()
 export class InformationsEmailsService {
+  private readonly logger = new Logger("InformationsEmailsService");
+
   constructor(
     @InjectRepository(InformationsEmail)
     private informationsEmailRepository: Repository<InformationsEmail>,
@@ -14,6 +16,9 @@ export class InformationsEmailsService {
   async ajoute(
     creeInformationsEmailDto: CreeInformationsEmailDto,
   ): Promise<InformationsEmail> {
+    this.logger.debug(
+      `Ajout d'un email : ${JSON.stringify(creeInformationsEmailDto)}`,
+    );
     return this.informationsEmailRepository.save(creeInformationsEmailDto);
   }
 }

--- a/anssi-nis2-api/src/main.ts
+++ b/anssi-nis2-api/src/main.ts
@@ -13,17 +13,21 @@ const activeFiltrageIp = (app: NestExpressApplication) => {
 
   if (!activerFiltrageIp) return;
 
-  app.use(IpFilter(ipAutorisees, {
-    // IpFilter n'utilise pas `trust proxy` par défaut, donc :
-    // X-Real-Ip fournit l'adresse du noeud qui précéde le reverse proxy Scalingo
-    detectIp: (requete) => requete.headers['x-real-ip'] as string,
-    mode: "allow",
-    log: false,
-  }));
+  app.use(
+    IpFilter(ipAutorisees, {
+      // IpFilter n'utilise pas `trust proxy` par défaut, donc :
+      // X-Real-Ip fournit l'adresse du noeud qui précéde le reverse proxy Scalingo
+      detectIp: (requete) => requete.headers["x-real-ip"] as string,
+      mode: "allow",
+      log: false,
+    }),
+  );
 };
 
 async function bootstrap() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    logger: ["error", "warn", "verbose", "debug", "log", "fatal"],
+  });
   app.set("trust proxy", 1);
   activeFiltrageIp(app);
   app.enableCors();

--- a/anssi-nis2-ui/index.html
+++ b/anssi-nis2-ui/index.html
@@ -1,57 +1,48 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <!-- <link rel="icon" href="https://template.incubateur.net/~/@gouvfr/dsfr/dist/favicon/favicon.svg" />
-<link href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" rel="stylesheet"> -->
-    <link rel="apple-touch-icon" href="/dsfr/favicon/apple-touch-icon.png" />
-    <link rel="icon" href="/dsfr/favicon/favicon.svg" type="image/svg+xml" />
-    <link
-      rel="shortcut icon"
-      href="/dsfr/favicon/favicon.ico"
-      type="image/x-icon"
-    />
-    <link
-      rel="manifest"
-      href="/dsfr/favicon/manifest.webmanifest"
-      crossorigin="use-credentials"
-    />
+<head>
+  <meta charset="UTF-8" />
+  <link rel="apple-touch-icon" href="/dsfr/favicon/apple-touch-icon.png" />
+  <link rel="icon" href="/dsfr/favicon/favicon.svg" type="image/svg+xml" />
+  <link
+    rel="shortcut icon"
+    href="/dsfr/favicon/favicon.ico"
+    type="image/x-icon"
+  />
+  <link
+    rel="manifest"
+    href="/dsfr/favicon/manifest.webmanifest"
+    crossorigin="use-credentials"
+  />
 
-    <link rel="stylesheet" href="/dsfr/utility/icons/icons.min.css" />
-    <link rel="stylesheet" href="/dsfr/dsfr.min.css" />
+  <link rel="stylesheet" href="/dsfr/utility/icons/icons.min.css" />
+  <link rel="stylesheet" href="/dsfr/dsfr.min.css" />
 
-    <!--<link rel="preload" href="/dsfr/fonts/Marianne-Light.woff2" as="font" crossorigin="anonymous" />-->
-    <!--<link rel="preload" href="/dsfr/fonts/Marianne-Light_Italic.woff2" as="font" crossorigin="anonymous" />-->
-    <link
-      rel="preload"
-      href="/dsfr/fonts/Marianne-Regular.woff2"
-      as="font"
-      crossorigin="anonymous"
-    />
-    <!--<link rel="preload" href="/dsfr/fonts/Marianne-Regular_Italic.woff2" as="font" crossorigin="anonymous" />-->
-    <link
-      rel="preload"
-      href="/dsfr/fonts/Marianne-Medium.woff2"
-      as="font"
-      crossorigin="anonymous"
-    />
-    <!--<link rel="preload" href="/dsfr/fonts/Marianne-Medium_Italic.woff2" as="font" crossorigin="anonymous" />-->
-    <link
-      rel="preload"
-      href="/dsfr/fonts/Marianne-Bold.woff2"
-      as="font"
-      crossorigin="anonymous"
-    />
-    <!--<link rel="preload" href="/dsfr/fonts/Marianne-Bold_Italic.woff2" as="font" crossorigin="anonymous" />-->
-    <!--<link rel="preload" href="/dsfr/fonts/Spectral-Regular.woff2" as="font" crossorigin="anonymous" />-->
-    <!--<link rel="preload" href="/dsfr/fonts/Spectral-ExtraBold.woff2" as="font" crossorigin="anonymous" />-->
+  <link
+    rel="preload"
+    href="/dsfr/fonts/Marianne-Regular.woff2"
+    as="font"
+    crossorigin="anonymous"
+  />
+  <link
+    rel="preload"
+    href="/dsfr/fonts/Marianne-Medium.woff2"
+    as="font"
+    crossorigin="anonymous"
+  />
+  <link
+    rel="preload"
+    href="/dsfr/fonts/Marianne-Bold.woff2"
+    as="font"
+    crossorigin="anonymous"
+  />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MonEspaceNIS2</title>
-  </head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MonEspaceNIS2</title>
+</head>
 
-  <body>
-    <div id="root"></div>
-    <script type="module" src="./src/main.tsx"></script>
-  </body>
+<body>
+<div id="root"></div>
+<script type="module" src="./src/main.tsx"></script>
+</body>
 </html>

--- a/anssi-nis2-ui/src/Services/sendFormDataToApi.ts
+++ b/anssi-nis2-ui/src/Services/sendFormDataToApi.ts
@@ -14,7 +14,6 @@ export const sendFormDataToApi: EnvoieDonneesFormulaire = async (
 ) => {
   const data = JSON.stringify(formData);
   const simulationApi = genereClientApi();
-  console.log(`Calling to API Simulation ${data}`);
   simulationApi
     .post("/", formData)
     .then((response) => console.log(JSON.stringify(response)));
@@ -22,23 +21,15 @@ export const sendFormDataToApi: EnvoieDonneesFormulaire = async (
 };
 export const enregistreInformationsEmailVersApi: EnregistreInformationsEmail =
   async (informations: InformationsEmail) => {
-    const ERREUR_APPEL = 0;
-    let retourApi: AggregatInformationsEmail | typeof ERREUR_APPEL =
-      ERREUR_APPEL;
     const simulationApi = genereClientApi("informations-emails");
-    console.log(`[API info email - POST] ${JSON.stringify(informations)}`);
     simulationApi
       .post("/", informations)
       .then((response) => {
-        retourApi = response.data as AggregatInformationsEmail;
-        console.log(JSON.stringify(response));
+        response.data as AggregatInformationsEmail;
       })
       .catch((reason) => {
-        retourApi = ERREUR_APPEL;
         throw Error(
           "Erreur à l'appel API d'enregistrement d'email : " + reason,
         );
       });
-    if (retourApi !== ERREUR_APPEL) return retourApi;
-    else throw Error("Erreur à l'appel API d'enregistrement d'email");
   };


### PR DESCRIPTION
Sentry remonte des erreurs `Error: Erreur à l'appel API d'enregistrement d'email`

- Suppression de cette erreur inutile due à un mauvais traitement du retour d'appel POST vers l'API
- Ajout d'une possibilité de configuration du niveau de logs