### PR TITLE
fix: ajoute l'espace entre le champs de la page infolettre

### DIFF
--- a/anssi-nis2-ui/src/App.scss
+++ b/anssi-nis2-ui/src/App.scss
@@ -1010,3 +1010,7 @@ nav.fr-nis2-faq-menu.fr-sidemenu {
 .fr-follow .fr-link::before {
   background: #272771;
 }
+
+.texte-edito .fr-nis2-formulaire-restez-informes .fr-checkbox-group {
+  margin-top: 16px;
+}

--- a/anssi-nis2-ui/src/Components/RestezInformes.tsx
+++ b/anssi-nis2-ui/src/Components/RestezInformes.tsx
@@ -11,7 +11,7 @@ const RestezInformes: DefaultComponentExtensible<RestezInformesProps> = ({
   const [emailEnregistre, setEmailEnregistre] = useState(false);
 
   return (
-    <div className="fr-container">
+    <div className="fr-container fr-nis2-page-restez-informe">
       <h2 className="fr-text-action-high--blue-france fr-h1">
         Restez informés
       </h2>


### PR DESCRIPTION
### Ajoute l'espace nécessaire entre le champs email et la ligne checkbox sur page formulaire

![image](https://github.com/betagouv/anssi-nis2/assets/125454097/7a764470-01f0-4695-a4ad-b104dec1d20a)
