### PR TITLE
Ajout de l'étape "Résultat"

### DIFF
--- a/anssi-nis2-ui/.env.template
+++ b/anssi-nis2-ui/.env.template
@@ -10,4 +10,9 @@ VITE_SENTRY_ENVIRONNEMENT=
 VITE_CRISP_URL_FAQ= # URL vers la FAQ Crisp. Laisser vide pour masquer le lien vers la FAQ.
 
 # Feature flags
-VITE_VERSION_QUESTIONNAIRE= # `v1` pour afficher le questionnaire legacy. `v2` pour le questionnaire refacto. Utilisera `v1` si la variable est absente.
+
+# `v1` pour afficher le questionnaire legacy.
+# `v2` pour le questionnaire refacto.
+# `all` pour les 2 en parallèle.
+# Utilisera `v1` si la variable est absente.
+VITE_VERSION_QUESTIONNAIRE=

--- a/anssi-nis2-ui/src/Components/Simulateur/ChargeurEtape.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/ChargeurEtape.tsx
@@ -37,6 +37,7 @@ const ChargeurEtapeCalcule: DefaultComponent = () => {
     import.meta.env.VITE_VERSION_QUESTIONNAIRE || "v1";
   const afficheQuestionnaireV1 = versionQuestionnaire === "v1";
   const afficheQuestionnaireV2 = versionQuestionnaire === "v2";
+  const afficheLesDeux = versionQuestionnaire === "all";
 
   return (
     <>
@@ -47,7 +48,7 @@ const ChargeurEtapeCalcule: DefaultComponent = () => {
         </title>
       </Helmet>
       <div id="debutForm"></div>
-      {afficheQuestionnaireV1 && (
+      {(afficheQuestionnaireV1 || afficheLesDeux) && (
         <ElementRendu
           propageActionSimulateur={propageActionSimulateur}
           donneesFormulaire={donneesFormulaireSimulateur}
@@ -55,7 +56,7 @@ const ChargeurEtapeCalcule: DefaultComponent = () => {
           etatEtapes={etatEtapes}
         />
       )}
-      {afficheQuestionnaireV2 && <Questionnaire />}
+      {(afficheQuestionnaireV2 || afficheLesDeux) && <Questionnaire />}
     </>
   );
 };

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeResultat.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeResultat.tsx
@@ -1,0 +1,41 @@
+import { LigneResultat } from "../Resultats/LigneResultat.tsx";
+import { DonneesFormulaireSimulateur } from "anssi-nis2-core/src/Domain/Simulateur/services/DonneesFormulaire/DonneesFormulaire.definitions.ts";
+import { ConvertisseurDonneesBrutesVersEtatDonneesSimulateur } from "anssi-nis2-core/src/Domain/Simulateur/services/Eligibilite/ReponseEtat.fabriques.ts";
+import { EtatRegulation } from "anssi-nis2-core/src/Domain/Simulateur/services/Eligibilite/EtatRegulation.definitions.ts";
+import { evalueEtatRegulation } from "anssi-nis2-core/src/Domain/Simulateur/services/Eligibilite/EvalueEtatRegulation.ts";
+import { LigneResterInformer } from "../Resultats/LigneResterInformer.tsx";
+import {
+  affichePdf,
+  getModeFormulaireEmail,
+} from "../SimulateurEtapeResult.aide.ts";
+import { estRegule } from "anssi-nis2-core/src/Domain/Simulateur/Regulation.predicats.ts";
+import { LigneEtMaintenant } from "../Resultats/LigneEtMaintenant.tsx";
+import { EnSavoirPlus } from "../Resultats/EnSavoirPlus.tsx";
+import { LigneBienDebuter } from "../Resultats/LigneBienDebuter.tsx";
+import { LigneReseauxSociaux } from "../Resultats/LigneReseauxSociaux.tsx";
+
+export const EtapeResultat = ({
+  reponses,
+}: {
+  reponses: DonneesFormulaireSimulateur;
+}) => {
+  const donneesReponse =
+    ConvertisseurDonneesBrutesVersEtatDonneesSimulateur.depuisDonneesFormulaireSimulateur(
+      reponses,
+    ) as EtatRegulation;
+  const etatRegulation = evalueEtatRegulation(donneesReponse);
+  const modeFormulaireEmail = getModeFormulaireEmail(etatRegulation.decision);
+
+  return (
+    <>
+      <LigneResultat etatRegulation={etatRegulation} />
+      <LigneResterInformer mode={modeFormulaireEmail} />
+      {estRegule(etatRegulation.decision) && <LigneEtMaintenant />}
+      {estRegule(etatRegulation.decision) && <EnSavoirPlus />}
+      <LigneBienDebuter
+        avecPdf={affichePdf(etatRegulation.decision)(reponses)}
+      />
+      <LigneReseauxSociaux />
+    </>
+  );
+};

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSousSecteursActivite.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSousSecteursActivite.tsx
@@ -17,7 +17,7 @@ export function EtapeSousSecteursActivite({
   secteursChoisis,
   onValider,
 }: {
-  secteursChoisis: SecteurActivite[];
+  secteursChoisis: SecteurComposite[];
   onValider: (sousSecteurs: SousSecteurActivite[]) => void;
 }) {
   const [reponse, setReponse] = useState<

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -22,6 +22,7 @@ import { EtapeTailleEntitePrivee } from "./EtapesRefacto/EtapeTailleEntitePrivee
 import { EtapeSecteursActivite } from "./EtapesRefacto/EtapeSecteursActivite.tsx";
 import { SousSecteurActivite } from "anssi-nis2-core/src/Domain/Simulateur/SousSecteurActivite.definitions.ts";
 import { EtapeSousSecteursActivite } from "./EtapesRefacto/EtapeSousSecteursActivite.tsx";
+import { EtapeResultat } from "./EtapesRefacto/EtapeResultat.tsx";
 
 function executer(actions: ActionQuestionnaire[]): EtatQuestionnaire {
   return actions.reduce(
@@ -39,7 +40,7 @@ export const Questionnaire = () => {
       valideEtapeAppartenanceUE(["france"]),
       valideTypeStructure(["privee"]),
       valideTailleEntitePrivee(["petit"], ["petit"]),
-      valideSecteursActivite(["energie", "transports"]),
+      valideSecteursActivite(["autreSecteurActivite"]),
     ]),
   ).current;
 
@@ -94,6 +95,6 @@ export const Questionnaire = () => {
       );
 
     case "resultat":
-      return <h1>RÉSULTAT</h1>;
+      return <EtapeResultat reponses={etat} />;
   }
 };

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -23,6 +23,8 @@ import { EtapeSecteursActivite } from "./EtapesRefacto/EtapeSecteursActivite.tsx
 import { SousSecteurActivite } from "anssi-nis2-core/src/Domain/Simulateur/SousSecteurActivite.definitions.ts";
 import { EtapeSousSecteursActivite } from "./EtapesRefacto/EtapeSousSecteursActivite.tsx";
 import { EtapeResultat } from "./EtapesRefacto/EtapeResultat.tsx";
+import { estUnSecteurAvecDesSousSecteurs } from "anssi-nis2-core/src/Domain/Simulateur/services/SecteurActivite/SecteurActivite.predicats.ts";
+import { SecteurComposite } from "anssi-nis2-core/src/Domain/Simulateur/SecteurActivite.definitions.ts";
 
 function executer(actions: ActionQuestionnaire[]): EtatQuestionnaire {
   return actions.reduce(
@@ -40,7 +42,8 @@ export const Questionnaire = () => {
       valideEtapeAppartenanceUE(["france"]),
       valideTypeStructure(["privee"]),
       valideTailleEntitePrivee(["petit"], ["petit"]),
-      valideSecteursActivite(["autreSecteurActivite"]),
+      valideSecteursActivite(["banqueSecteurBancaire", "eauxUsees", "energie"]),
+      valideSousSecteursActivite(["gaz", "hydrogene"]),
     ]),
   ).current;
 
@@ -87,7 +90,11 @@ export const Questionnaire = () => {
     case "sousSecteursActivite":
       return (
         <EtapeSousSecteursActivite
-          secteursChoisis={etat.secteurActivite}
+          secteursChoisis={
+            etat.secteurActivite.filter((s) =>
+              estUnSecteurAvecDesSousSecteurs(s),
+            ) as SecteurComposite[]
+          }
           onValider={(reponse: SousSecteurActivite[]) =>
             dispatch(valideSousSecteursActivite(reponse))
           }

--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -3,6 +3,7 @@ import {
   DesignationOperateurServicesEssentiels,
   TrancheChiffreAffaire,
   TrancheNombreEmployes,
+  TypeEntitePublique,
   TypeStructure,
 } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { TypeEtape } from "anssi-nis2-core/src/Domain/Simulateur/InformationsEtape.ts";
@@ -13,6 +14,7 @@ import {
   estUnSecteurAvecDesSousSecteurs,
 } from "anssi-nis2-core/src/Domain/Simulateur/services/SecteurActivite/SecteurActivite.predicats.ts";
 import { SousSecteurActivite } from "anssi-nis2-core/src/Domain/Simulateur/SousSecteurActivite.definitions.ts";
+import { Activite } from "anssi-nis2-core/src/Domain/Simulateur/Activite.definitions.ts";
 
 export interface EtatQuestionnaire {
   etapeCourante: TypeEtape;
@@ -23,6 +25,12 @@ export interface EtatQuestionnaire {
   trancheChiffreAffaire: TrancheChiffreAffaire[];
   secteurActivite: SecteurActivite[];
   sousSecteurActivite: SousSecteurActivite[];
+  activites: Activite[];
+  typeEntitePublique: TypeEntitePublique[];
+  localisationFournitureServicesNumeriques: AppartenancePaysUnionEuropeenne[];
+  paysDecisionsCyber: AppartenancePaysUnionEuropeenne[];
+  paysOperationsCyber: AppartenancePaysUnionEuropeenne[];
+  paysPlusGrandNombreSalaries: AppartenancePaysUnionEuropeenne[];
 }
 
 export const etatParDefaut: EtatQuestionnaire = {
@@ -34,6 +42,12 @@ export const etatParDefaut: EtatQuestionnaire = {
   trancheChiffreAffaire: [],
   secteurActivite: [],
   sousSecteurActivite: [],
+  activites: [],
+  typeEntitePublique: [],
+  localisationFournitureServicesNumeriques: [],
+  paysDecisionsCyber: [],
+  paysOperationsCyber: [],
+  paysPlusGrandNombreSalaries: [],
 };
 
 export const reducerQuestionnaire = (


### PR DESCRIPTION
### Contexte

On continue sur la lancée de #108 en ajoutant l'étape `<Resultat />`.
Toujours la même stratégie : duplication des composants et réutilisation du code métier existant.