### PR TITLE
Fix: affiche activité même si sous-secteur autre est coché

### DIFF
--- a/anssi-nis2-ui/src/Components/Simulateur/Etapes/EtapesQuestionnaire.ts
+++ b/anssi-nis2-ui/src/Components/Simulateur/Etapes/EtapesQuestionnaire.ts
@@ -28,6 +28,10 @@ const contientDesSecteursAvecSousSecteurs = ({
   secteurActivite,
 }: DonneesFormulaireSimulateur) =>
   secteurActivite.some(estUnSecteurAvecDesSousSecteurs);
+const contientUniquementDesSecteursAvecSousSecteurs = ({
+  secteurActivite,
+}: DonneesFormulaireSimulateur) =>
+  secteurActivite.every(estUnSecteurAvecDesSousSecteurs);
 
 const sousEtapeSousSecteur =
   fabriquesInformationsEtapes.sousEtapeConditionnelle(
@@ -159,9 +163,12 @@ export const etapesQuestionnaire: CollectionInformationsEtapes =
       validationReponsesActivites,
       "activites",
       {
-        ignoreSi: et(
+        ignoreSi: ou(
           contientAutreSecteurActiviteUniquement,
-          contientSousSecteurAutresUniquement,
+          et(
+            contientUniquementDesSecteursAvecSousSecteurs,
+            contientSousSecteurAutresUniquement,
+          ),
         ),
         sousEtapeConditionnelle: sousEtapeLocalisationVariantes,
       },

--- a/anssi-nis2-ui/src/Components/Simulateur/Etapes/EtapesQuestionnaire.ts
+++ b/anssi-nis2-ui/src/Components/Simulateur/Etapes/EtapesQuestionnaire.ts
@@ -159,7 +159,7 @@ export const etapesQuestionnaire: CollectionInformationsEtapes =
       validationReponsesActivites,
       "activites",
       {
-        ignoreSi: ou(
+        ignoreSi: et(
           contientAutreSecteurActiviteUniquement,
           contientSousSecteurAutresUniquement,
         ),

--- a/commun/core/src/Domain/Simulateur/Activite.operations.ts
+++ b/commun/core/src/Domain/Simulateur/Activite.operations.ts
@@ -38,7 +38,6 @@ import {
   SousSecteurActivite,
 } from "./SousSecteurActivite.definitions";
 import { ValeurCleSectorielle } from "./ValeurCleSectorielle.definitions";
-import { estUnSecteurAvecDesSousSecteurs } from "./services/SecteurActivite/SecteurActivite.predicats";
 import { cartographieSousSecteursParSecteur } from "./services/SousSecteurActivite/SousSecteurActivite.operations";
 
 export const activitesParSecteurEtSousSecteur: Record<
@@ -121,13 +120,13 @@ const rempliSousSecteurs = (
   libelleSecteursActivite: string,
   libellesSousSecteursActivite: Record<SousSecteurActivite, string>,
 ): AssociationSectorielleActivite[] => {
-  if (
-    estUnSecteurAvecDesSousSecteurs(secteur) &&
-    listeSousSecteurs.length === 0
-  )
-    throw Error(
-      `Houla! un secteur avec sous secteurs n'en n'a pas ! ${secteur}`,
-    );
+  // if (
+  //   estUnSecteurAvecDesSousSecteurs(secteur) && !estSousSecteurAutre(secteur) &&
+  //   listeSousSecteurs.length === 0
+  // )
+  //   throw Error(
+  //     `Houla! un secteur avec sous secteurs n'en n'a pas ! ${secteur}`,
+  //   );
   return listeSousSecteurs.length === 0
     ? collecteTitresSecteursSimples(
         libelleSecteursActivite,

--- a/commun/core/src/Domain/Simulateur/services/SousSecteurActivite/SousSecteurActivite.operations.ts
+++ b/commun/core/src/Domain/Simulateur/services/SousSecteurActivite/SousSecteurActivite.operations.ts
@@ -1,4 +1,3 @@
-import { DonneesFormulaireSimulateur } from "../DonneesFormulaire/DonneesFormulaire.definitions";
 import {
   SecteurActivite,
   SecteurComposite,
@@ -8,6 +7,7 @@ import {
   PeutEtreSousSecteurActivite,
   SousSecteurActivite,
 } from "../../SousSecteurActivite.definitions";
+import { DonneesFormulaireSimulateur } from "../DonneesFormulaire/DonneesFormulaire.definitions";
 import { fabriqueTuplesSecteurSousSecteur } from "../SecteurActivite/SecteurActivite.operations";
 import {
   contientSousSecteur,
@@ -34,6 +34,20 @@ const extraitSousSecteursOuListeVide = (
   estUnSecteurAvecDesSousSecteurs(secteur)
     ? extraitSousSecteurs(secteur as SecteurComposite, sousSecteurActivite)
     : [];
+
+const genereSecteurAvecSousSecteurs = (
+  secteur: SecteurActivite,
+  sousSecteurActivite: SousSecteurActivite[],
+): Array<[SecteurActivite, SousSecteurActivite[]]> => {
+  const sousSecteurs = extraitSousSecteursOuListeVide(
+    secteur,
+    sousSecteurActivite.filter(estSousSecteurListe),
+  );
+  return estUnSecteurAvecDesSousSecteurs(secteur) && sousSecteurs.length === 0
+    ? []
+    : [[secteur, sousSecteurs]];
+};
+
 export const cartographieSousSecteursParSecteur = ({
   secteurActivite,
   sousSecteurActivite,
@@ -43,13 +57,7 @@ export const cartographieSousSecteursParSecteur = ({
     .reduce<[SecteurActivite, SousSecteurActivite[]][]>(
       (acc, secteur) => [
         ...acc,
-        [
-          secteur,
-          extraitSousSecteursOuListeVide(
-            secteur,
-            sousSecteurActivite.filter(estSousSecteurListe),
-          ),
-        ],
+        ...genereSecteurAvecSousSecteurs(secteur, sousSecteurActivite),
       ],
       [],
     );


### PR DESCRIPTION
### Reproduire le bug

1. Aller dans le test d'éligibilité
2. Avancer jusqu'à étape 5 "Secteurs"
3. Sélectionner "Transports" et "Santé"
4. Passer à l'étape suivante (5 - "Sous-secteurs")
5. Cocher uniquement "Autre sous-secteur transports"
6. Cliquer sur suivant

**Attendu** : Affiche les activités pour le secteur "Santé"

**Obtenu**: Affiche la page résultats (non-régulé)