### PR TITLE
Ajout de l'étape « Localisation de votre activité » pour les services numériques

### DIFF
--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
@@ -1,0 +1,81 @@
+import { Stepper } from "@codegouvfr/react-dsfr/Stepper";
+import BlocPrincipal from "../../BlocPrincipal.tsx";
+import { FormSimulateur } from "../Etapes";
+import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
+import { useState } from "react";
+import { AppartenancePaysUnionEuropeenne } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
+
+export function EtapeLocalisationServicesNumeriques() {
+  const [reponse, setReponse] = useState<AppartenancePaysUnionEuropeenne[]>([]);
+
+  const coche = (pays: AppartenancePaysUnionEuropeenne) => {
+    setReponse([...reponse, pays]);
+  };
+
+  const decoche = (pays: AppartenancePaysUnionEuropeenne) => {
+    setReponse(reponse.filter((r) => r !== pays));
+  };
+
+  return (
+    <BlocPrincipal className="fond-gris" id="etape-formulaire">
+      <Stepper
+        currentStep={6}
+        stepCount={6}
+        title="Localisation de votre activité"
+        className="fr-mb-5w"
+      />
+      <hr className="fr-pb-5w" />
+
+      <FormSimulateur>
+        <div className="fr-fieldset__element">
+          <p>
+            Dans quels états membres de l’Union Européenne fournissez-vous des
+            services numériques ?
+          </p>
+          <p className="fr-text-mention--grey fr-text--sm">
+            Fournisseur de réseaux de communications électroniques publics, ou
+            Fournisseur de services de communications électroniques accessibles
+            au public.
+          </p>
+          <Checkbox
+            options={[
+              {
+                label: "France",
+                nativeInputProps: {
+                  value: "france",
+                  checked: reponse.includes("france"),
+                  onChange: (e) => {
+                    if (e.target.checked) coche("france");
+                    else decoche("france");
+                  },
+                },
+              },
+              {
+                label: "Autres états membres de l'Union Européenne",
+                nativeInputProps: {
+                  value: "autre",
+                  checked: reponse.includes("autre"),
+                  onChange: (e) => {
+                    if (e.target.checked) coche("autre");
+                    else decoche("autre");
+                  },
+                },
+              },
+              {
+                label: "Autres états hors Union Européenne",
+                nativeInputProps: {
+                  value: "horsue",
+                  checked: reponse.includes("horsue"),
+                  onChange: (e) => {
+                    if (e.target.checked) coche("horsue");
+                    else decoche("horsue");
+                  },
+                },
+              },
+            ]}
+          />
+        </div>
+      </FormSimulateur>
+    </BlocPrincipal>
+  );
+}

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
@@ -4,8 +4,13 @@ import { FormSimulateur } from "../Etapes";
 import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { useState } from "react";
 import { AppartenancePaysUnionEuropeenne } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 
-export function EtapeLocalisationServicesNumeriques() {
+export function EtapeLocalisationServicesNumeriques({
+  onValider,
+}: {
+  onValider: (pays: AppartenancePaysUnionEuropeenne[]) => void;
+}) {
   const [reponse, setReponse] = useState<AppartenancePaysUnionEuropeenne[]>([]);
 
   const coche = (pays: AppartenancePaysUnionEuropeenne) => {
@@ -76,6 +81,24 @@ export function EtapeLocalisationServicesNumeriques() {
           />
         </div>
       </FormSimulateur>
+
+      <div id="stepper-navigation">
+        <p className="message-validation">Sélectionnez au moins une réponse</p>
+        <div className="conteneur-actions">
+          <ButtonsGroup
+            alignment="right"
+            buttons={[
+              {
+                children: "Suivant",
+                onClick: () => onValider(reponse),
+                type: "submit",
+                disabled: reponse.length === 0,
+              },
+            ]}
+            inlineLayoutWhen="sm and up"
+          />
+        </div>
+      </div>
     </BlocPrincipal>
   );
 }

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -12,6 +12,7 @@ import {
   valideEtapeDesignation,
   valideEtapePrealable,
   valideLocalisationEtablissementPrincipal,
+  valideLocalisationServicesNumeriques,
   valideSecteursActivite,
   valideSousSecteursActivite,
   valideTailleEntitePrivee,
@@ -126,7 +127,13 @@ export const Questionnaire = () => {
       );
 
     case "localisationFournitureServicesNumeriques":
-      return <EtapeLocalisationServicesNumeriques />;
+      return (
+        <EtapeLocalisationServicesNumeriques
+          onValider={(pays) =>
+            dispatch(valideLocalisationServicesNumeriques(pays))
+          }
+        />
+      );
 
     case "resultat":
       return <EtapeResultat reponses={etat} />;

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -29,6 +29,7 @@ import { EtapeActivites } from "./EtapesRefacto/EtapeActivites.tsx";
 import { selectSecteursPourSaisieActivites } from "../../questionnaire/selecteursQuestionnaire.ts";
 import { estUnSecteurAvecDesSousSecteurs } from "anssi-nis2-core/src/Domain/Simulateur/services/SecteurActivite/SecteurActivite.predicats.ts";
 import { SecteurComposite } from "anssi-nis2-core/src/Domain/Simulateur/SecteurActivite.definitions.ts";
+import { EtapeLocalisationServicesNumeriques } from "./EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx";
 import { EtapeLocalisationEtablissementPrincipal } from "./EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx";
 
 function executer(actions: ActionQuestionnaire[]): EtatQuestionnaire {
@@ -49,7 +50,7 @@ export const Questionnaire = () => {
       valideTailleEntitePrivee(["petit"], ["petit"]),
       valideSecteursActivite(["banqueSecteurBancaire", "eauxUsees", "energie"]),
       valideSousSecteursActivite(["gaz", "hydrogene"]),
-      valideActivites(["fournisseurServicesDNS"]),
+      valideActivites(["fournisseurReseauxCommunicationElectroniquesPublics"]),
     ]),
   ).current;
 
@@ -123,6 +124,9 @@ export const Questionnaire = () => {
           }
         />
       );
+
+    case "localisationFournitureServicesNumeriques":
+      return <EtapeLocalisationServicesNumeriques />;
 
     case "resultat":
       return <EtapeResultat reponses={etat} />;

--- a/anssi-nis2-ui/src/questionnaire/actions.ts
+++ b/anssi-nis2-ui/src/questionnaire/actions.ts
@@ -19,7 +19,8 @@ export type ActionQuestionnaire =
   | ActionValideSecteursActivite
   | ActionValideSousSecteursActivite
   | ActionValideActivites
-  | ActionValideLocalisationEtablissementPrincipal;
+  | ActionValideLocalisationEtablissementPrincipal
+  | ActionValideLocalisationServicesNumeriques;
 
 interface ActionVide {
   type: "VIDE";
@@ -70,6 +71,11 @@ interface ActionValideLocalisationEtablissementPrincipal {
   paysDecision: AppartenancePaysUnionEuropeenne[];
   paysOperation: AppartenancePaysUnionEuropeenne[];
   paysSalaries: AppartenancePaysUnionEuropeenne[];
+}
+
+interface ActionValideLocalisationServicesNumeriques {
+  type: "VALIDE_ETAPE_LOCALISATION_SERVICES_NUMERIQUES";
+  pays: AppartenancePaysUnionEuropeenne[];
 }
 
 export const valideEtapePrealable = (): ActionSuivantEtapePrealable => ({
@@ -127,15 +133,20 @@ export const valideActivites = (
   activites,
 });
 
-export function valideLocalisationEtablissementPrincipal(
+export const valideLocalisationEtablissementPrincipal = (
   paysDecision: AppartenancePaysUnionEuropeenne[],
   paysOperation: AppartenancePaysUnionEuropeenne[],
   paysSalaries: AppartenancePaysUnionEuropeenne[],
-): ActionValideLocalisationEtablissementPrincipal {
-  return {
-    type: "VALIDE_ETAPE_LOCALISATION_ETABLISSEMENT_PRINCIPAL",
-    paysDecision,
-    paysOperation,
-    paysSalaries,
-  };
-}
+): ActionValideLocalisationEtablissementPrincipal => ({
+  type: "VALIDE_ETAPE_LOCALISATION_ETABLISSEMENT_PRINCIPAL",
+  paysDecision,
+  paysOperation,
+  paysSalaries,
+});
+
+export const valideLocalisationServicesNumeriques = (
+  pays: AppartenancePaysUnionEuropeenne[],
+): ActionValideLocalisationServicesNumeriques => ({
+  type: "VALIDE_ETAPE_LOCALISATION_SERVICES_NUMERIQUES",
+  pays,
+});

--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -165,6 +165,28 @@ export const reducerQuestionnaire = (
       };
     }
 
+    case "VALIDE_ETAPE_LOCALISATION_SERVICES_NUMERIQUES": {
+      const versEtablissementPrincipal =
+        contientUnParmi(...etat.secteurActivite)([
+          "gestionServicesTic",
+          "fournisseursNumeriques",
+        ]) ||
+        contientUnParmi(...etat.activites)([
+          "registresNomsDomainesPremierNiveau",
+          "fournisseurServicesDNS",
+          "fournisseurServicesInformatiqueNuage",
+          "fournisseurServiceCentresDonnees",
+          "fournisseurReseauxDiffusionContenu",
+        ]);
+
+      return {
+        ...etat,
+        localisationFournitureServicesNumeriques: action.pays,
+        etapeCourante: versEtablissementPrincipal
+          ? "localisationEtablissementPrincipal"
+          : "resultat",
+      };
+    }
     case "VIDE":
     default:
       return etat;

--- a/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
@@ -11,6 +11,7 @@ import {
   valideEtapeDesignation,
   valideEtapePrealable,
   valideLocalisationEtablissementPrincipal,
+  valideLocalisationServicesNumeriques,
   valideSecteursActivite,
   valideSousSecteursActivite,
   valideTailleEntitePrivee,
@@ -257,6 +258,58 @@ describe("Le reducer du Questionnaire", () => {
         valideActivites(["fournisseurServicesDNS"]),
         valideLocalisationEtablissementPrincipal(peuImporte, [], []),
       ]);
+
+      expect(etat.etapeCourante).toBe("resultat");
+    });
+  });
+
+  describe("à la validation de l'étape « Localisation des services numériques »", () => {
+    it("sauvegarde les informations de l'étape", () => {
+      const etat = executer([valideLocalisationServicesNumeriques(["france"])]);
+
+      expect(etat.localisationFournitureServicesNumeriques).toEqual(["france"]);
+    });
+
+    const secteursVersEtablissementPrincipal: SecteurActivite[] = [
+      "gestionServicesTic",
+      "fournisseursNumeriques",
+    ];
+    secteursVersEtablissementPrincipal.forEach((secteur) =>
+      it(`navigue vers l'étape « Localisation de l'établissement principal » si le secteur « ${secteur} » est présent`, () => {
+        const peuImporte = "france";
+        const etat = executer([
+          valideSecteursActivite([secteur]),
+          valideLocalisationServicesNumeriques([peuImporte]),
+        ]);
+
+        expect(etat.etapeCourante).toEqual(
+          "localisationEtablissementPrincipal",
+        );
+      }),
+    );
+
+    const activitesVersEtablissementPrincipal: Activite[] = [
+      "registresNomsDomainesPremierNiveau",
+      "fournisseurServicesDNS",
+      "fournisseurServicesInformatiqueNuage",
+      "fournisseurServiceCentresDonnees",
+      "fournisseurReseauxDiffusionContenu",
+    ];
+    activitesVersEtablissementPrincipal.forEach((activite) =>
+      it(`navigue vers l'étape « Localisation de l'établissement principal » si l'activité « ${activite} » est présente`, () => {
+        const peuImporte = "france";
+
+        const etat = executer([
+          valideActivites([activite]),
+          valideLocalisationServicesNumeriques([peuImporte]),
+        ]);
+
+        expect(etat.etapeCourante).toBe("localisationEtablissementPrincipal");
+      }),
+    );
+
+    it("navigue vers l'étape « Résultat » le cas échéant", () => {
+      const etat = executer([valideLocalisationServicesNumeriques(["france"])]);
 
       expect(etat.etapeCourante).toBe("resultat");
     });


### PR DESCRIPTION
### Contexte
À la suite de #108, #111,  #115 & #116 on passe maintenant à l'étape _« Localisation de votre activité »_.
On continue sur le design existant avec l'enrichissement du reducer et l'ajout du composant `<EtapeLocalisationServicesNumeriques />`.