### PR TITLE
Ajoute la prise en charge du bouton « Précédent »

### DIFF
--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeActivites.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeActivites.tsx
@@ -11,8 +11,8 @@ import { secteurDe } from "anssi-nis2-core/src/Domain/Simulateur/services/SousSe
 import { activitesParSecteurEtSousSecteur } from "anssi-nis2-core/src/Domain/Simulateur/Activite.operations.ts";
 import { libellesActivites } from "../../../References/LibellesActivites.ts";
 import { listeDescriptionsActivites } from "../../../References/ListeDescriptionsActivites.ts";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import { Activite } from "anssi-nis2-core/src/Domain/Simulateur/Activite.definitions.ts";
+import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 type SecteurAvecActivite = SecteurSimple | SousSecteurActivite;
 type StateDeReponse = Partial<Record<SecteurAvecActivite, Activite[]>>;
@@ -84,25 +84,11 @@ export function EtapeActivites({
         </div>
       </FormSimulateur>
 
-      <div id="stepper-navigation">
-        <p className="message-validation">
-          Sélectionnez au moins une réponse par secteur
-        </p>
-        <div className="conteneur-actions">
-          <ButtonsGroup
-            alignment="right"
-            buttons={[
-              {
-                children: "Suivant",
-                onClick: () => onValider(toutesLesActivitesDe(reponse)),
-                type: "submit",
-                disabled: unSecteurEstSansReponse(reponse),
-              },
-            ]}
-            inlineLayoutWhen="sm and up"
-          />
-        </div>
-      </div>
+      <PrecedentSuivant
+        message="Sélectionnez au moins une réponse par secteur"
+        onSuivant={() => onValider(toutesLesActivitesDe(reponse))}
+        suivantDisabled={unSecteurEstSansReponse(reponse)}
+      />
     </BlocPrincipal>
   );
 }

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeActivites.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeActivites.tsx
@@ -20,9 +20,11 @@ type StateDeReponse = Partial<Record<SecteurAvecActivite, Activite[]>>;
 export function EtapeActivites({
   secteursChoisis,
   onValider,
+  onPrecedent,
 }: {
   secteursChoisis: SecteurAvecActivite[];
   onValider: (activites: Activite[]) => void;
+  onPrecedent: () => void;
 }) {
   const [reponse, setReponse] = useState<StateDeReponse>(
     dictionnaireParSecteur(secteursChoisis),
@@ -88,6 +90,7 @@ export function EtapeActivites({
         message="Sélectionnez au moins une réponse par secteur"
         onSuivant={() => onValider(toutesLesActivitesDe(reponse))}
         suivantDisabled={unSecteurEstSansReponse(reponse)}
+        onPrecedent={onPrecedent}
       />
     </BlocPrincipal>
   );

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeAppartenanceUE.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeAppartenanceUE.tsx
@@ -8,8 +8,10 @@ import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export const EtapeAppartenanceUE = ({
   onValider,
+  onPrecedent,
 }: {
   onValider: (reponse: AppartenancePaysUnionEuropeenne[]) => void;
+  onPrecedent: () => void;
 }) => {
   const [reponse, setReponse] = useState<AppartenancePaysUnionEuropeenne[]>([]);
 
@@ -74,6 +76,7 @@ export const EtapeAppartenanceUE = ({
         message="Sélectionnez une réponse"
         onSuivant={() => onValider(reponse)}
         suivantDisabled={reponse.length === 0}
+        onPrecedent={onPrecedent}
       />
     </BlocPrincipal>
   );

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeAppartenanceUE.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeAppartenanceUE.tsx
@@ -4,7 +4,7 @@ import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import BlocPrincipal from "../../BlocPrincipal.tsx";
 import { FormSimulateur } from "../Etapes";
 import { AppartenancePaysUnionEuropeenne } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export const EtapeAppartenanceUE = ({
   onValider,
@@ -70,23 +70,11 @@ export const EtapeAppartenanceUE = ({
         </div>
       </div>
 
-      <div id="stepper-navigation">
-        <p className="message-validation">Sélectionnez une réponse</p>
-        <div className="conteneur-actions">
-          <ButtonsGroup
-            alignment="right"
-            buttons={[
-              {
-                children: "Suivant",
-                onClick: () => onValider(reponse),
-                type: "submit",
-                disabled: reponse.length === 0,
-              },
-            ]}
-            inlineLayoutWhen="sm and up"
-          />
-        </div>
-      </div>
+      <PrecedentSuivant
+        message="Sélectionnez une réponse"
+        onSuivant={() => onValider(reponse)}
+        suivantDisabled={reponse.length === 0}
+      />
     </BlocPrincipal>
   );
 };

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeDesignation.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeDesignation.tsx
@@ -4,7 +4,7 @@ import { FormSimulateur } from "../Etapes";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import { DesignationOperateurServicesEssentiels } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { useState } from "react";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export const EtapeDesignation = ({
   onValider,
@@ -56,23 +56,11 @@ export const EtapeDesignation = ({
         </div>
       </FormSimulateur>
 
-      <div id="stepper-navigation">
-        <p className="message-validation">Sélectionnez une réponse</p>
-        <div className="conteneur-actions">
-          <ButtonsGroup
-            alignment="right"
-            buttons={[
-              {
-                children: "Suivant",
-                onClick: () => onValider(reponse),
-                type: "submit",
-                disabled: reponse.length === 0,
-              },
-            ]}
-            inlineLayoutWhen="sm and up"
-          />
-        </div>
-      </div>
+      <PrecedentSuivant
+        message="Sélectionnez une réponse"
+        onSuivant={() => onValider(reponse)}
+        suivantDisabled={reponse.length === 0}
+      />
     </BlocPrincipal>
   );
 };

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx
@@ -15,12 +15,14 @@ type StateDeReponse = {
 
 export function EtapeLocalisationEtablissementPrincipal({
   onValider,
+  onPrecedent,
 }: {
   onValider: (
     paysDecision: AppartenancePaysUnionEuropeenne[],
     paysOperation: AppartenancePaysUnionEuropeenne[],
     paysSalaries: AppartenancePaysUnionEuropeenne[],
   ) => void;
+  onPrecedent: () => void;
 }) {
   const [reponse, setReponse] = useState<StateDeReponse>({
     paysDecision: [],
@@ -86,6 +88,7 @@ export function EtapeLocalisationEtablissementPrincipal({
           )
         }
         suivantDisabled={!reponseEstComplete(reponse)}
+        onPrecedent={onPrecedent}
       />
     </BlocPrincipal>
   );

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx
@@ -4,8 +4,8 @@ import BlocPrincipal from "../../BlocPrincipal.tsx";
 import { FormSimulateur } from "../Etapes";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import { AppartenancePaysUnionEuropeenne } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
+import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 type StateDeReponse = {
   paysDecision: AppartenancePaysUnionEuropeenne[];
@@ -76,28 +76,17 @@ export function EtapeLocalisationEtablissementPrincipal({
         )}
       </FormSimulateur>
 
-      <div id="stepper-navigation">
-        <p className="message-validation">Sélectionnez au moins une réponse</p>
-        <div className="conteneur-actions">
-          <ButtonsGroup
-            alignment="right"
-            buttons={[
-              {
-                children: "Suivant",
-                onClick: () =>
-                  onValider(
-                    reponse.paysDecision,
-                    reponse.paysOperation,
-                    reponse.paysSalaries,
-                  ),
-                type: "submit",
-                disabled: !reponseEstComplete(reponse),
-              },
-            ]}
-            inlineLayoutWhen="sm and up"
-          />
-        </div>
-      </div>
+      <PrecedentSuivant
+        message="Sélectionnez au moins une réponse"
+        onSuivant={() =>
+          onValider(
+            reponse.paysDecision,
+            reponse.paysOperation,
+            reponse.paysSalaries,
+          )
+        }
+        suivantDisabled={!reponseEstComplete(reponse)}
+      />
     </BlocPrincipal>
   );
 }

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
@@ -8,8 +8,10 @@ import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export function EtapeLocalisationServicesNumeriques({
   onValider,
+  onPrecedent,
 }: {
   onValider: (pays: AppartenancePaysUnionEuropeenne[]) => void;
+  onPrecedent: () => void;
 }) {
   const [reponse, setReponse] = useState<AppartenancePaysUnionEuropeenne[]>([]);
 
@@ -86,6 +88,7 @@ export function EtapeLocalisationServicesNumeriques({
         message="Sélectionnez au moins une réponse"
         onSuivant={() => onValider(reponse)}
         suivantDisabled={reponse.length === 0}
+        onPrecedent={onPrecedent}
       />
     </BlocPrincipal>
   );

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
@@ -4,7 +4,7 @@ import { FormSimulateur } from "../Etapes";
 import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { useState } from "react";
 import { AppartenancePaysUnionEuropeenne } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export function EtapeLocalisationServicesNumeriques({
   onValider,
@@ -82,23 +82,11 @@ export function EtapeLocalisationServicesNumeriques({
         </div>
       </FormSimulateur>
 
-      <div id="stepper-navigation">
-        <p className="message-validation">Sélectionnez au moins une réponse</p>
-        <div className="conteneur-actions">
-          <ButtonsGroup
-            alignment="right"
-            buttons={[
-              {
-                children: "Suivant",
-                onClick: () => onValider(reponse),
-                type: "submit",
-                disabled: reponse.length === 0,
-              },
-            ]}
-            inlineLayoutWhen="sm and up"
-          />
-        </div>
-      </div>
+      <PrecedentSuivant
+        message="Sélectionnez au moins une réponse"
+        onSuivant={() => onValider(reponse)}
+        suivantDisabled={reponse.length === 0}
+      />
     </BlocPrincipal>
   );
 }

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSecteursActivite.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSecteursActivite.tsx
@@ -5,7 +5,7 @@ import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { libellesSecteursActivite } from "../../../References/LibellesSecteursActivite.ts";
 import { useState } from "react";
 import { SecteurActivite } from "anssi-nis2-core/src/Domain/Simulateur/SecteurActivite.definitions.ts";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export const EtapeSecteursActivite = ({
   onValider,
@@ -45,23 +45,11 @@ export const EtapeSecteursActivite = ({
         </div>
       </FormSimulateur>
 
-      <div id="stepper-navigation">
-        <p className="message-validation">Sélectionnez au moins une réponse</p>
-        <div className="conteneur-actions">
-          <ButtonsGroup
-            alignment="right"
-            buttons={[
-              {
-                children: "Suivant",
-                onClick: () => onValider(reponse),
-                type: "submit",
-                disabled: reponse.length === 0,
-              },
-            ]}
-            inlineLayoutWhen="sm and up"
-          />
-        </div>
-      </div>
+      <PrecedentSuivant
+        message="Sélectionnez au moins une réponse"
+        onSuivant={() => onValider(reponse)}
+        suivantDisabled={reponse.length === 0}
+      />
     </BlocPrincipal>
   );
 };

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSecteursActivite.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSecteursActivite.tsx
@@ -9,8 +9,10 @@ import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export const EtapeSecteursActivite = ({
   onValider,
+  onPrecedent,
 }: {
   onValider: (reponse: SecteurActivite[]) => void;
+  onPrecedent: () => void;
 }) => {
   const [reponse, setReponse] = useState<SecteurActivite[]>([]);
 
@@ -49,6 +51,7 @@ export const EtapeSecteursActivite = ({
         message="Sélectionnez au moins une réponse"
         onSuivant={() => onValider(reponse)}
         suivantDisabled={reponse.length === 0}
+        onPrecedent={onPrecedent}
       />
     </BlocPrincipal>
   );

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSousSecteursActivite.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSousSecteursActivite.tsx
@@ -11,7 +11,7 @@ import { fabriqueTupleSecteurSousSecteurs } from "anssi-nis2-core/src/Domain/Sim
 import { libellesSousSecteursActivite } from "../../../References/LibellesSousSecteursActivite.ts";
 import { useState } from "react";
 import { SousSecteurActivite } from "anssi-nis2-core/src/Domain/Simulateur/SousSecteurActivite.definitions.ts";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export function EtapeSousSecteursActivite({
   secteursChoisis,
@@ -81,25 +81,11 @@ export function EtapeSousSecteursActivite({
         </div>
       </FormSimulateur>
 
-      <div id="stepper-navigation">
-        <p className="message-validation">
-          Sélectionnez au moins une réponse par secteur
-        </p>
-        <div className="conteneur-actions">
-          <ButtonsGroup
-            alignment="right"
-            buttons={[
-              {
-                children: "Suivant",
-                onClick: () => onValider(tousLesSousSecteursDe(reponse)),
-                type: "submit",
-                disabled: unSecteurEstSansReponse(reponse),
-              },
-            ]}
-            inlineLayoutWhen="sm and up"
-          />
-        </div>
-      </div>
+      <PrecedentSuivant
+        message="Sélectionnez au moins une réponse par secteur"
+        onSuivant={() => onValider(tousLesSousSecteursDe(reponse))}
+        suivantDisabled={unSecteurEstSansReponse(reponse)}
+      />
     </BlocPrincipal>
   );
 }

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSousSecteursActivite.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSousSecteursActivite.tsx
@@ -16,9 +16,11 @@ import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 export function EtapeSousSecteursActivite({
   secteursChoisis,
   onValider,
+  onPrecedent,
 }: {
   secteursChoisis: SecteurComposite[];
   onValider: (sousSecteurs: SousSecteurActivite[]) => void;
+  onPrecedent: () => void;
 }) {
   const [reponse, setReponse] = useState<
     Partial<Record<SecteurActivite, SousSecteurActivite[]>>
@@ -85,6 +87,7 @@ export function EtapeSousSecteursActivite({
         message="Sélectionnez au moins une réponse par secteur"
         onSuivant={() => onValider(tousLesSousSecteursDe(reponse))}
         suivantDisabled={unSecteurEstSansReponse(reponse)}
+        onPrecedent={onPrecedent}
       />
     </BlocPrincipal>
   );

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTailleEntitePrivee.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTailleEntitePrivee.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { Stepper } from "@codegouvfr/react-dsfr/Stepper";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import BlocPrincipal from "../../BlocPrincipal.tsx";
 import { FormSimulateur } from "../Etapes";
 import {
   TrancheChiffreAffaire,
   TrancheNombreEmployes,
 } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
+import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export function EtapeTailleEntitePrivee({
   onValider,
@@ -95,27 +95,13 @@ export function EtapeTailleEntitePrivee({
         </div>
       </FormSimulateur>
 
-      <div id="stepper-navigation">
-        <p className="message-validation">
-          Sélectionnez une réponse pour chaque critère
-        </p>
-        <div className="conteneur-actions">
-          <ButtonsGroup
-            alignment="right"
-            buttons={[
-              {
-                children: "Suivant",
-                onClick: () => onValider(reponseNombre, reponseChiffreAffaire),
-                type: "submit",
-                disabled:
-                  reponseNombre.length === 0 ||
-                  reponseChiffreAffaire.length === 0,
-              },
-            ]}
-            inlineLayoutWhen="sm and up"
-          />
-        </div>
-      </div>
+      <PrecedentSuivant
+        message="Sélectionnez une réponse pour chaque critère"
+        onSuivant={() => onValider(reponseNombre, reponseChiffreAffaire)}
+        suivantDisabled={
+          reponseNombre.length === 0 || reponseChiffreAffaire.length === 0
+        }
+      />
     </BlocPrincipal>
   );
 }

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTailleEntitePrivee.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTailleEntitePrivee.tsx
@@ -11,11 +11,13 @@ import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export function EtapeTailleEntitePrivee({
   onValider,
+  onPrecedent,
 }: {
   onValider: (
     nombre: TrancheNombreEmployes[],
     chiffreAffaire: TrancheChiffreAffaire[],
   ) => void;
+  onPrecedent: () => void;
 }) {
   const [reponseNombre, setReponseNombre] = useState<TrancheNombreEmployes[]>(
     [],
@@ -101,6 +103,7 @@ export function EtapeTailleEntitePrivee({
         suivantDisabled={
           reponseNombre.length === 0 || reponseChiffreAffaire.length === 0
         }
+        onPrecedent={onPrecedent}
       />
     </BlocPrincipal>
   );

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTypeStructure.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTypeStructure.tsx
@@ -4,7 +4,7 @@ import { FormSimulateur } from "../Etapes";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import { useState } from "react";
 import { TypeStructure } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export const EtapeTypeStructure = ({
   onValider,
@@ -60,23 +60,11 @@ export const EtapeTypeStructure = ({
         </div>
       </div>
 
-      <div id="stepper-navigation">
-        <p className="message-validation">Sélectionnez une réponse</p>
-        <div className="conteneur-actions">
-          <ButtonsGroup
-            alignment="right"
-            buttons={[
-              {
-                children: "Suivant",
-                onClick: () => onValider(reponse),
-                type: "submit",
-                disabled: reponse.length === 0,
-              },
-            ]}
-            inlineLayoutWhen="sm and up"
-          />
-        </div>
-      </div>
+      <PrecedentSuivant
+        message="Sélectionnez une réponse"
+        onSuivant={() => onValider(reponse)}
+        suivantDisabled={reponse.length === 0}
+      />
     </BlocPrincipal>
   );
 };

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTypeStructure.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTypeStructure.tsx
@@ -8,8 +8,10 @@ import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
 
 export const EtapeTypeStructure = ({
   onValider,
+  onPrecedent,
 }: {
   onValider: (typeStructure: TypeStructure[]) => void;
+  onPrecedent: () => void;
 }) => {
   const [reponse, setReponse] = useState<TypeStructure[]>([]);
 
@@ -64,6 +66,7 @@ export const EtapeTypeStructure = ({
         message="Sélectionnez une réponse"
         onSuivant={() => onValider(reponse)}
         suivantDisabled={reponse.length === 0}
+        onPrecedent={onPrecedent}
       />
     </BlocPrincipal>
   );

--- a/anssi-nis2-ui/src/Components/Simulateur/PrecedentSuivant.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/PrecedentSuivant.tsx
@@ -1,0 +1,27 @@
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+
+export function PrecedentSuivant(props: {
+  message: string;
+  onSuivant: () => void;
+  suivantDisabled: boolean;
+}) {
+  return (
+    <div id="stepper-navigation">
+      <p className="message-validation">{props.message}</p>
+      <div className="conteneur-actions">
+        <ButtonsGroup
+          alignment="right"
+          buttons={[
+            {
+              children: "Suivant",
+              onClick: props.onSuivant,
+              type: "submit",
+              disabled: props.suivantDisabled,
+            },
+          ]}
+          inlineLayoutWhen="sm and up"
+        />
+      </div>
+    </div>
+  );
+}

--- a/anssi-nis2-ui/src/Components/Simulateur/PrecedentSuivant.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/PrecedentSuivant.tsx
@@ -4,6 +4,7 @@ export function PrecedentSuivant(props: {
   message: string;
   onSuivant: () => void;
   suivantDisabled: boolean;
+  onPrecedent?: () => void;
 }) {
   return (
     <div id="stepper-navigation">
@@ -12,6 +13,12 @@ export function PrecedentSuivant(props: {
         <ButtonsGroup
           alignment="right"
           buttons={[
+            {
+              children: "Précédent",
+              onClick: props.onPrecedent,
+              priority: "secondary",
+              disabled: !props.onPrecedent,
+            },
             {
               children: "Suivant",
               onClick: props.onSuivant,

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -32,7 +32,7 @@ import { estUnSecteurAvecDesSousSecteurs } from "anssi-nis2-core/src/Domain/Simu
 import { SecteurComposite } from "anssi-nis2-core/src/Domain/Simulateur/SecteurActivite.definitions.ts";
 import { EtapeLocalisationServicesNumeriques } from "./EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx";
 import { EtapeLocalisationEtablissementPrincipal } from "./EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx";
-import { quiSupporteUndo } from "../../questionnaire/quiSupporteUndo.ts";
+import { quiSupporteUndo, undo } from "../../questionnaire/quiSupporteUndo.ts";
 
 function executer(actions: ActionQuestionnaire[]): EtatQuestionnaire {
   return actions.reduce(
@@ -51,8 +51,8 @@ export const Questionnaire = () => {
       valideTypeStructure(["privee"]),
       valideTailleEntitePrivee(["petit"], ["petit"]),
       valideSecteursActivite(["gestionServicesTic"]),
-      // valideSousSecteursActivite(["gaz", "hydrogene"]),
-      // valideActivites(["fournisseurReseauxCommunicationElectroniquesPublics"]),
+      valideSousSecteursActivite(["gaz", "hydrogene"]),
+      valideActivites(["fournisseurReseauxCommunicationElectroniquesPublics"]),
     ]),
   ).current;
 
@@ -76,12 +76,14 @@ export const Questionnaire = () => {
       return (
         <EtapeAppartenanceUE
           onValider={(reponse) => dispatch(valideEtapeAppartenanceUE(reponse))}
+          onPrecedent={() => dispatch(undo())}
         />
       );
     case "typeStructure":
       return (
         <EtapeTypeStructure
           onValider={(reponse) => dispatch(valideTypeStructure(reponse))}
+          onPrecedent={() => dispatch(undo())}
         />
       );
     case "tailleEntitePrivee":
@@ -90,12 +92,14 @@ export const Questionnaire = () => {
           onValider={(nombre, chiffreAffaire) =>
             dispatch(valideTailleEntitePrivee(nombre, chiffreAffaire))
           }
+          onPrecedent={() => dispatch(undo())}
         />
       );
     case "secteursActivite":
       return (
         <EtapeSecteursActivite
           onValider={(reponse) => dispatch(valideSecteursActivite(reponse))}
+          onPrecedent={() => dispatch(undo())}
         />
       );
 
@@ -110,6 +114,7 @@ export const Questionnaire = () => {
           onValider={(reponse: SousSecteurActivite[]) =>
             dispatch(valideSousSecteursActivite(reponse))
           }
+          onPrecedent={() => dispatch(undo())}
         />
       );
 
@@ -118,6 +123,7 @@ export const Questionnaire = () => {
         <EtapeActivites
           secteursChoisis={selectSecteursPourSaisieActivites(etat.courant)}
           onValider={(reponse) => dispatch(valideActivites(reponse))}
+          onPrecedent={() => dispatch(undo())}
         />
       );
 
@@ -127,6 +133,7 @@ export const Questionnaire = () => {
           onValider={(...pays) =>
             dispatch(valideLocalisationEtablissementPrincipal(...pays))
           }
+          onPrecedent={() => dispatch(undo())}
         />
       );
 
@@ -136,6 +143,7 @@ export const Questionnaire = () => {
           onValider={(pays) =>
             dispatch(valideLocalisationServicesNumeriques(pays))
           }
+          onPrecedent={() => dispatch(undo())}
         />
       );
 

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -1,12 +1,10 @@
-import { useReducer, useRef } from "react";
+import { useReducer } from "react";
 import {
   etatParDefaut,
-  EtatQuestionnaire,
   reducerQuestionnaire,
 } from "../../questionnaire/reducerQuestionnaire.ts";
 import { EtapePrealable } from "./EtapesRefacto/EtapePrealable.tsx";
 import {
-  ActionQuestionnaire,
   valideActivites,
   valideEtapeAppartenanceUE,
   valideEtapeDesignation,
@@ -34,31 +32,10 @@ import { EtapeLocalisationServicesNumeriques } from "./EtapesRefacto/EtapeLocali
 import { EtapeLocalisationEtablissementPrincipal } from "./EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx";
 import { quiSupporteUndo, undo } from "../../questionnaire/quiSupporteUndo.ts";
 
-function executer(actions: ActionQuestionnaire[]): EtatQuestionnaire {
-  return actions.reduce(
-    (etat: EtatQuestionnaire, action: ActionQuestionnaire) =>
-      reducerQuestionnaire(etat, action),
-    etatParDefaut,
-  );
-}
-
 export const Questionnaire = () => {
-  const etatInitial: EtatQuestionnaire = useRef(
-    executer([
-      valideEtapePrealable(),
-      valideEtapeDesignation(["non"]),
-      valideEtapeAppartenanceUE(["france"]),
-      valideTypeStructure(["privee"]),
-      valideTailleEntitePrivee(["petit"], ["petit"]),
-      valideSecteursActivite(["gestionServicesTic"]),
-      valideSousSecteursActivite(["gaz", "hydrogene"]),
-      valideActivites(["fournisseurReseauxCommunicationElectroniquesPublics"]),
-    ]),
-  ).current;
-
   const [etat, dispatch] = useReducer(
-    quiSupporteUndo(reducerQuestionnaire, etatInitial),
-    { courant: etatInitial, precedents: [] },
+    quiSupporteUndo(reducerQuestionnaire, etatParDefaut),
+    { courant: etatParDefaut, precedents: [] },
   );
 
   switch (etat.courant.etapeCourante) {

--- a/anssi-nis2-ui/src/questionnaire/quiSupporteUndo.ts
+++ b/anssi-nis2-ui/src/questionnaire/quiSupporteUndo.ts
@@ -1,0 +1,27 @@
+type AvecUndo<TEtat> = { precedents: TEtat[]; courant: TEtat };
+
+export function quiSupporteUndo<TEtat, TAction extends { type: string }>(
+  reducerWrappe: (etat: TEtat, action: TAction) => TEtat,
+  etatInitial: TEtat,
+): (etat: AvecUndo<TEtat>, action: TAction | ActionUndo) => AvecUndo<TEtat> {
+  const etatUndoInitial = { precedents: [], courant: etatInitial };
+
+  return (
+    etat: AvecUndo<TEtat> = etatUndoInitial,
+    action: TAction | ActionUndo,
+  ) => {
+    if (action.type === "UNDO") {
+      const [precedent, ...ancetres] = etat.precedents;
+      return { courant: precedent, precedents: ancetres };
+    }
+
+    const nouvelEtat = reducerWrappe(etat.courant, action as TAction);
+    return {
+      precedents: [etat.courant, ...etat.precedents],
+      courant: nouvelEtat,
+    };
+  };
+}
+
+export type ActionUndo = { type: "UNDO" };
+export const undo = (): ActionUndo => ({ type: "UNDO" });

--- a/anssi-nis2-ui/test/questionnaire/reducerUndo.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/reducerUndo.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { quiSupporteUndo, undo } from "../../src/questionnaire/quiSupporteUndo";
+
+type Incremente = { type: "+" };
+const incremente = (): Incremente => ({ type: "+" });
+
+const reducerPlusMoins = (etat: number, action: Incremente) => {
+  switch (action.type) {
+    case "+":
+      return etat + 1;
+    default:
+      return etat;
+  }
+};
+
+describe("Le reducer « Undo »", () => {
+  it("connaît, pour ses tests, un reducer qui peut incrémenter un nombre", () => {
+    expect(reducerPlusMoins(0, incremente())).toBe(1);
+  });
+
+  it("wrap un reducer existant sans rien faire de plus", () => {
+    const supporteLeUndo = quiSupporteUndo(reducerPlusMoins, 0);
+
+    expect(supporteLeUndo).not.toBe(undefined);
+  });
+
+  it("stocke les états précédents dans un champ `precedents`", () => {
+    const plusMoinsAvecUndo = quiSupporteUndo(reducerPlusMoins, 0);
+
+    const un = plusMoinsAvecUndo(undefined, incremente());
+    const deux = plusMoinsAvecUndo(un, incremente());
+
+    expect(deux.precedents).toEqual([1, 0]);
+    expect(deux.courant).toEqual(2);
+  });
+
+  it("permet de revenir à l'état précédent avec une action dédiée", () => {
+    const plusMoinsAvecUndo = quiSupporteUndo(reducerPlusMoins, 0);
+
+    const un = plusMoinsAvecUndo(undefined, incremente());
+    const deux = plusMoinsAvecUndo(un, incremente());
+    const apresUndo = plusMoinsAvecUndo(deux, undo());
+
+    expect(apresUndo.courant).toBe(1);
+    expect(apresUndo.precedents).toEqual([0]);
+  });
+});


### PR DESCRIPTION
### Contexte
Le questionnaire refactoré n'avait pas encore de prise en charge du « Précédent ».
Cette PR ajoute cette prise en charge.

### Architecture
Pour favoriser la composition, on passe par un `reducer` qui est dédié à la gestion du _Undo_.
Le bouton « Précédent » est assimilé à un _Undo_.
Donc cliquer sur « Précédent » ramène à l'étape précédente avec effacement de la donnée saisie. 
Techniquement cela correspond à la restauration d'un état précédent par le `reducer` dédié `anssi-nis2-ui/src/questionnaire/quiSupporteUndo.ts`.

À l'usage ça signifie que revenir à une étape précédente force à re-saisir les infos… mais ça évite un bug existant dans la précédente version du questionnaire :
 - je remplis jusqu'à l'avant-dernière étape le questionnaire
 - je reviens au début avec des clics sur Précédent
 - je change une grosse partie de mes réponses, de sorte que j'emprunte un chemin différent dans le questionnaire
 - arrivé ici, l'ancien questionnaire va calculer l'éligibilité sur la base de toutes les réponses saisies… même celles saisies avant les clics sur Précédent.

Avec la version de cette PR, qui efface les saisies, c'est moins agréable à utiliser mais les données utilisées pour le calcul sont toujours celles saisies par l'utilisateur.