### PR TITLE
Fix/corrige bug doublons valeurs activites

### DIFF
--- a/anssi-nis2-ui/src/References/LibellesActivites.ts
+++ b/anssi-nis2-ui/src/References/LibellesActivites.ts
@@ -19,6 +19,7 @@ export const libellesActivites: Record<Activite, string> = {
   autreActiviteAdministrationPublique: "Autre activité",
   autreActiviteConstructionVehiculesAutomobilesRemorquesSemi: "Autre activité",
   autreActiviteEauPotable: "Autre activité",
+  autreActiviteEauxUsees: "Autre activité",
   autreActiviteElectricite: "Autre activité",
   autreActiviteEspace: "Autre activité",
   autreActiviteFabricationDispositifsMedicaux: "Autre activité",
@@ -33,7 +34,7 @@ export const libellesActivites: Record<Activite, string> = {
   autreActiviteGestionDechets: "Autre activité",
   autreActiviteGestionServicesTic: "Autre activité",
   autreActiviteHydrogene: "Autre activité",
-  autreActiviteInfrastructureMarcheFinancie: "Autre activité",
+  autreActiviteInfrastructureMarcheFinancier: "Autre activité",
   autreActiviteInfrastructureNumerique: "Autre activité",
   autreActivitePetrole: "Autre activité",
   autreActiviteProductionTransformationDistributionDenreesAlimentaires:
@@ -244,7 +245,8 @@ export const libellesActivites: Record<Activite, string> = {
   gestionnaireInstallationStockage: "Gestionnaires d’installation de stockage",
   gestionnaireReseau: "Gestionnaire de réseau de distribution",
   gestionnaireReseauDistribution: "Gestionnaires de réseau de distribution",
-  gestionnaireReseauTransport: "Gestionnaire de réseau de transport",
+  gestionnaireReseauTransportGaz: "Gestionnaire de réseau de transport",
+  gestionnaireReseauTransportElectricite: "Gestionnaire de réseau de transport",
   laboratoireReferenceUE: "Laboratoires de référence de l’Union européenne",
   operateurDesigneMarcheOuNemo: "Opérateur désigné du marché ou NEMO",
   operateurReseauChaleurFroid:

--- a/anssi-nis2-ui/src/References/ListeDescriptionsActivites.ts
+++ b/anssi-nis2-ui/src/References/ListeDescriptionsActivites.ts
@@ -10,6 +10,7 @@ export const listeDescriptionsActivites: Record<
   autreActiviteAdministrationPublique: [],
   autreActiviteConstructionVehiculesAutomobilesRemorquesSemi: [],
   autreActiviteEauPotable: [],
+  autreActiviteEauxUsees: [],
   autreActiviteElectricite: [],
   autreActiviteEspace: [],
   autreActiviteFabricationDispositifsMedicaux: [],
@@ -22,7 +23,7 @@ export const listeDescriptionsActivites: Record<
   autreActiviteGestionDechets: [],
   autreActiviteGestionServicesTic: [],
   autreActiviteHydrogene: [],
-  autreActiviteInfrastructureMarcheFinancie: [],
+  autreActiviteInfrastructureMarcheFinancier: [],
   autreActiviteInfrastructureNumerique: [],
   autreActivitePetrole: [],
   autreActiviteProductionTransformationDistributionDenreesAlimentaires: [],
@@ -541,7 +542,7 @@ export const listeDescriptionsActivites: Record<
         "avec d'autres réseaux, et chargée de garantir la capacité à long terme du réseau à satisfaire une demande raisonnable de distribution d’électricité.",
     },
   ],
-  gestionnaireReseauTransport: [
+  gestionnaireReseauTransportElectricite: [
     {
       titre: "Gestionnaire de réseau de transport",
       description:
@@ -550,6 +551,7 @@ export const listeDescriptionsActivites: Record<
         "avec d'autres réseaux, et chargée de garantir la capacité à long terme du réseau à satisfaire une demande raisonnable de transport d’électricité.",
     },
   ],
+  gestionnaireReseauTransportGaz: [],
   laboratoireReferenceUE: [],
   operateurDesigneMarcheOuNemo: [
     {

--- a/commun/core/src/Domain/Simulateur/Activite.valeurs.ts
+++ b/commun/core/src/Domain/Simulateur/Activite.valeurs.ts
@@ -3,7 +3,7 @@ export const ValeursActivitesElectricite = [
   "entrepriseElectriciteRemplissantFonctionFourniture",
   "exploitantsPointRecharge",
   "gestionnaireReseau",
-  "gestionnaireReseauTransport",
+  "gestionnaireReseauTransportElectricite",
   "operateurDesigneMarcheOuNemo",
   "producteur",
   "autreActiviteElectricite",
@@ -21,7 +21,7 @@ export const ValeursActivitesPetrole = [
 export const ValeursActivitesGaz = [
   "entrepriseFourniture",
   "gestionnaireReseauDistribution",
-  "gestionnaireReseauTransport",
+  "gestionnaireReseauTransportGaz",
   "gestionnaireInstallationStockage",
   "gestionnaireInstallationGNL",
   "autreActiviteGaz",
@@ -72,7 +72,7 @@ export const ValeursActivitesSecteurBancaire = [
 export const ValeursActivitesInfrastructureMarcheFinancier = [
   "exploitantsPlateformesNegociation",
   "contrepartieCentrales",
-  "autreActiviteInfrastructureMarcheFinancie",
+  "autreActiviteInfrastructureMarcheFinancier",
 ] as const;
 export const ValeursActivitesSante = [
   "prestataireSoinsSante",
@@ -88,7 +88,7 @@ export const ValeursActivitesEauPotable = [
 ] as const;
 export const ValeursActivitesEauUsees = [
   "collectantEvacuantTraitantEaux",
-  "autreActiviteEauPotable",
+  "autreActiviteEauUsees",
 ] as const;
 
 export const ValeursActivitesInfrastructureNumeriqueFournisseursCommElecPublics =

--- a/commun/core/src/Domain/Simulateur/Activite.valeurs.ts
+++ b/commun/core/src/Domain/Simulateur/Activite.valeurs.ts
@@ -88,7 +88,7 @@ export const ValeursActivitesEauPotable = [
 ] as const;
 export const ValeursActivitesEauUsees = [
   "collectantEvacuantTraitantEaux",
-  "autreActiviteEauUsees",
+  "autreActiviteEauxUsees",
 ] as const;
 
 export const ValeursActivitesInfrastructureNumeriqueFournisseursCommElecPublics =


### PR DESCRIPTION
### Contexte

Des activités sont en doublons et provoquent des erreurs :
- dans l'affichage précis de leur description en infobulle
- dans la comptabilisation des résultats (seulement activité "Autre" pour "Eaux usées")
