### PR TITLE
Évite les boucles infinies dans le questionnaire refacto

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -132,11 +132,11 @@ const valideEtape = (
       );
     case "VALIDE_ETAPE_ACTIVITES":
       return vaVers(
-        contientActiviteFournisseurNumeriquePublic(action.activites)
-          ? "localisationFournitureServicesNumeriques"
-          : contientUnSecteurTicOuFournisseurNumerique(etat.secteurActivite) ||
-            contientActiviteFournisseurServicesNumeriques(action.activites)
+        contientUnSecteurTicOuFournisseurNumerique(etat.secteurActivite) ||
+          contientActiviteFournisseurServicesNumeriques(action.activites)
           ? "localisationEtablissementPrincipal"
+          : contientActiviteFournisseurNumeriquePublic(action.activites)
+          ? "localisationFournitureServicesNumeriques"
           : "resultat",
         {
           activites: action.activites,

--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -149,15 +149,9 @@ const valideEtape = (
         paysPlusGrandNombreSalaries: action.paysSalaries,
       });
     case "VALIDE_ETAPE_LOCALISATION_SERVICES_NUMERIQUES":
-      return vaVers(
-        contientUnSecteurTicOuFournisseurNumerique(etat.secteurActivite) ||
-          contientActiviteFournisseurServicesNumeriques(etat.activites)
-          ? "localisationEtablissementPrincipal"
-          : "resultat",
-        {
-          localisationFournitureServicesNumeriques: action.pays,
-        },
-      );
+      return vaVers("resultat", {
+        localisationFournitureServicesNumeriques: action.pays,
+      });
     default:
       return {};
   }

--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -143,16 +143,11 @@ const valideEtape = (
         },
       );
     case "VALIDE_ETAPE_LOCALISATION_ETABLISSEMENT_PRINCIPAL":
-      return vaVers(
-        contientActiviteFournisseurNumeriquePublic(etat.activites)
-          ? "localisationFournitureServicesNumeriques"
-          : "resultat",
-        {
-          paysDecisionsCyber: action.paysDecision,
-          paysOperationsCyber: action.paysOperation,
-          paysPlusGrandNombreSalaries: action.paysSalaries,
-        },
-      );
+      return vaVers("resultat", {
+        paysDecisionsCyber: action.paysDecision,
+        paysOperationsCyber: action.paysOperation,
+        paysPlusGrandNombreSalaries: action.paysSalaries,
+      });
     case "VALIDE_ETAPE_LOCALISATION_SERVICES_NUMERIQUES":
       return vaVers(
         contientUnSecteurTicOuFournisseurNumerique(etat.secteurActivite) ||

--- a/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
@@ -19,7 +19,6 @@ import {
 } from "../../src/questionnaire/actions";
 import { SecteurActivite } from "anssi-nis2-core/src/Domain/Simulateur/SecteurActivite.definitions";
 import { Activite } from "anssi-nis2-core/src/Domain/Simulateur/Activite.definitions";
-import { AppartenancePaysUnionEuropeenne } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions";
 
 describe("Le reducer du Questionnaire", () => {
   it("indique l'étape « préalable » comme étape de départ", () => {
@@ -243,37 +242,9 @@ describe("Le reducer du Questionnaire", () => {
       expect(etat.paysPlusGrandNombreSalaries).toEqual(["france"]);
     });
 
-    const activitesVersLocalisationServicesNumeriques: Activite[] = [
-      "fournisseurReseauxCommunicationElectroniquesPublics",
-      "fournisseurServiceCommunicationElectroniquesPublics",
-    ];
-    activitesVersLocalisationServicesNumeriques.forEach((activite) =>
-      it(`navigue vers l'étape « Localisation des services numériques » lorsque l'activité « ${activite} » est présente`, () => {
-        const versEtablissementPrincipal = valideSecteursActivite([
-          "gestionServicesTic",
-        ]);
-        const peuImporte: AppartenancePaysUnionEuropeenne[] = ["france"];
-        const etat = executer([
-          versEtablissementPrincipal,
-          valideActivites([activite]),
-          valideLocalisationEtablissementPrincipal(peuImporte, [], []),
-        ]);
-
-        expect(etat.etapeCourante).toBe(
-          "localisationFournitureServicesNumeriques",
-        );
-      }),
-    );
-
-    it("navigue vers l'étape « Résultat » le cas échéant", () => {
-      const versEtablissementPrincipal = valideSecteursActivite([
-        "gestionServicesTic",
-      ]);
-      const peuImporte: AppartenancePaysUnionEuropeenne[] = ["france"];
+    it("navigue vers l'étape « Résultat »", () => {
       const etat = executer([
-        versEtablissementPrincipal,
-        valideActivites(["fournisseurServicesDNS"]),
-        valideLocalisationEtablissementPrincipal(peuImporte, [], []),
+        valideLocalisationEtablissementPrincipal(["france"], [], []),
       ]);
 
       expect(etat.etapeCourante).toBe("resultat");

--- a/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
@@ -167,6 +167,7 @@ describe("Le reducer du Questionnaire", () => {
       const etat = executer([valideActivites(["etablissementCredit"])]);
       expect(etat.activites).toEqual(["etablissementCredit"]);
     });
+
     describe("navigue vers l'étape « Localisation de l'établissement principal » ...", () => {
       const secteurVersLocalisationEtablissement: SecteurActivite[] = [
         "gestionServicesTic",
@@ -218,6 +219,22 @@ describe("Le reducer du Questionnaire", () => {
           );
         },
       );
+    });
+
+    it("navigue en priorité vers l'étape « Location de l'établissement principal » si les 2 étapes de localisation sont possibles", () => {
+      const versLocalisationServiceNumerique =
+        "fournisseurReseauxCommunicationElectroniquesPublics";
+      const versLocalisationEtablissementPrincipal =
+        "registresNomsDomainesPremierNiveau";
+
+      const etat = executer([
+        valideActivites([
+          versLocalisationServiceNumerique,
+          versLocalisationEtablissementPrincipal,
+        ]),
+      ]);
+
+      expect(etat.etapeCourante).toBe("localisationEtablissementPrincipal");
     });
 
     it("navigue vers l'étape « Résultat » si l'activité saisie n'est pas dans les cas précédents", () => {

--- a/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
@@ -258,45 +258,7 @@ describe("Le reducer du Questionnaire", () => {
       expect(etat.localisationFournitureServicesNumeriques).toEqual(["france"]);
     });
 
-    const secteursVersEtablissementPrincipal: SecteurActivite[] = [
-      "gestionServicesTic",
-      "fournisseursNumeriques",
-    ];
-    secteursVersEtablissementPrincipal.forEach((secteur) =>
-      it(`navigue vers l'étape « Localisation de l'établissement principal » si le secteur « ${secteur} » est présent`, () => {
-        const peuImporte = "france";
-        const etat = executer([
-          valideSecteursActivite([secteur]),
-          valideLocalisationServicesNumeriques([peuImporte]),
-        ]);
-
-        expect(etat.etapeCourante).toEqual(
-          "localisationEtablissementPrincipal",
-        );
-      }),
-    );
-
-    const activitesVersEtablissementPrincipal: Activite[] = [
-      "registresNomsDomainesPremierNiveau",
-      "fournisseurServicesDNS",
-      "fournisseurServicesInformatiqueNuage",
-      "fournisseurServiceCentresDonnees",
-      "fournisseurReseauxDiffusionContenu",
-    ];
-    activitesVersEtablissementPrincipal.forEach((activite) =>
-      it(`navigue vers l'étape « Localisation de l'établissement principal » si l'activité « ${activite} » est présente`, () => {
-        const peuImporte = "france";
-
-        const etat = executer([
-          valideActivites([activite]),
-          valideLocalisationServicesNumeriques([peuImporte]),
-        ]);
-
-        expect(etat.etapeCourante).toBe("localisationEtablissementPrincipal");
-      }),
-    );
-
-    it("navigue vers l'étape « Résultat » le cas échéant", () => {
+    it("navigue vers l'étape « Résultat »", () => {
       const etat = executer([valideLocalisationServicesNumeriques(["france"])]);
 
       expect(etat.etapeCourante).toBe("resultat");


### PR DESCRIPTION
### Bug
Dans le questionnaire refacto il est possible de déclencher une boucle infinie entre les étapes de « Localisation » si on donne les réponses suivantes :

```
Etape 1 - Non concerné NIS 1
Etape 2 - France
Etape 3 - Entreprise
Etape 4 - Moyen / moyen
Etape 5 - “Infrastructure numérique” et “Gestion des services TIC”
Etape 6 - “Fournisseurs de services de communications électroniques accessibles au public” 
          et “Fournisseurs de services gérés”
```
Après cela, les étapes bouclent, quelles que soient les réponses données.

### Correction
Ce bug n'est pas présent dans le questionnaire legacy. Le questionnaire legacy ne prévoit pas encore de permettre l'enchaînement des 2 étapes « Localisation ».
Le correctif proposé ici va dans ce sens : on supprime la possibilité de pouvoir enchaîner les 2 étapes.
On navigue systématiquement vers « Résultat ».