### PR TITLE
Navigue correctement entre les étapes de localisation

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -115,9 +115,7 @@ const valideEtape = (
           : certains(estUnSecteurAvecDesSousSecteurs)(action.secteurs)
           ? "sousSecteursActivite"
           : "activites",
-        {
-          secteurActivite: action.secteurs,
-        },
+        { secteurActivite: action.secteurs },
       );
     case "VALIDE_ETAPE_SOUS_SECTEURS_ACTIVITE":
       return vaVers(
@@ -138,16 +136,19 @@ const valideEtape = (
           : contientActiviteFournisseurNumeriquePublic(action.activites)
           ? "localisationFournitureServicesNumeriques"
           : "resultat",
-        {
-          activites: action.activites,
-        },
+        { activites: action.activites },
       );
     case "VALIDE_ETAPE_LOCALISATION_ETABLISSEMENT_PRINCIPAL":
-      return vaVers("resultat", {
-        paysDecisionsCyber: action.paysDecision,
-        paysOperationsCyber: action.paysOperation,
-        paysPlusGrandNombreSalaries: action.paysSalaries,
-      });
+      return vaVers(
+        contientActiviteFournisseurNumeriquePublic(etat.activites)
+          ? "localisationFournitureServicesNumeriques"
+          : "resultat",
+        {
+          paysDecisionsCyber: action.paysDecision,
+          paysOperationsCyber: action.paysOperation,
+          paysPlusGrandNombreSalaries: action.paysSalaries,
+        },
+      );
     case "VALIDE_ETAPE_LOCALISATION_SERVICES_NUMERIQUES":
       return vaVers("resultat", {
         localisationFournitureServicesNumeriques: action.pays,

--- a/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
@@ -259,6 +259,26 @@ describe("Le reducer du Questionnaire", () => {
       expect(etat.paysPlusGrandNombreSalaries).toEqual(["france"]);
     });
 
+    describe("navigue vers l'étape « Localisation de la fourniture des services numériques »", () => {
+      const activitesVersLocalisationServiceNumerique: Activite[] = [
+        "fournisseurReseauxCommunicationElectroniquesPublics",
+        "fournisseurServiceCommunicationElectroniquesPublics",
+      ];
+      it.each(activitesVersLocalisationServiceNumerique)(
+        `... si l'activité « %s » est présente`,
+        (activite) => {
+          const etat = executer([
+            valideActivites([activite]),
+            valideLocalisationEtablissementPrincipal(["france"], [], []),
+          ]);
+
+          expect(etat.etapeCourante).toBe(
+            "localisationFournitureServicesNumeriques",
+          );
+        },
+      );
+    });
+
     it("navigue vers l'étape « Résultat »", () => {
       const etat = executer([
         valideLocalisationEtablissementPrincipal(["france"], [], []),


### PR DESCRIPTION
Les précédents commits avaient résolu un problème de boucle infinie en dirigeant toujours vers « Résultat ». Désormais on est un peu plus fin : on passe d'abord par « Localisation de l'établissement principal » puis par « Localisation de la fourniture des services numériques » avant d'aller à « Résultat ».