### PR TITLE
Titre de page avec le questionnaire v2

### DIFF
--- a/anssi-nis2-ui/src/Components/Simulateur/ChargeurEtape.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/ChargeurEtape.tsx
@@ -7,9 +7,14 @@ import { etatEtapesInitial } from "./Etapes/EtapesQuestionnaire.ts";
 import { useReducteurDonneesFormulaireDuContexte } from "../../Services/AppContexte/AppContext.operations.ts";
 import { fabriqueInformationsBoutonsNavigation } from "../../Services/fabriques/BoutonsNavigation.fabrique.ts";
 import { traceEtapeSimulateur } from "../../Services/TraceurWeb/traceEtapeSimulateur.ts";
-import { AppContext } from "../../Services/AppContexte/AppContext.definition.ts";
 import { cartoComposants } from "../../Services/Simulateur/Transformateurs/TypeEtapeVersComposantEtape.transformateur.ts";
 import { Questionnaire } from "./Questionnaire.tsx";
+import { AppContext } from "../../Services/AppContexte/AppContext.definition.ts";
+import { quiSupporteUndo } from "../../questionnaire/quiSupporteUndo.ts";
+import {
+  etatParDefaut,
+  reducerQuestionnaire,
+} from "../../questionnaire/reducerQuestionnaire.ts";
 
 const ChargeurEtapeCalcule: DefaultComponent = () => {
   const [donneesFormulaireSimulateur, propageActionSimulateur] = useReducer(
@@ -26,6 +31,11 @@ const ChargeurEtapeCalcule: DefaultComponent = () => {
     etatEtapes,
     donneesFormulaireSimulateur,
     envoieDonneesFormulaire,
+  );
+
+  const [etatQuestionnaire, dispatchQuestionnaire] = useReducer(
+    quiSupporteUndo(reducerQuestionnaire, etatParDefaut),
+    { courant: etatParDefaut, precedents: [] },
   );
 
   useEffect(
@@ -56,7 +66,13 @@ const ChargeurEtapeCalcule: DefaultComponent = () => {
           etatEtapes={etatEtapes}
         />
       )}
-      {(afficheQuestionnaireV2 || afficheLesDeux) && <Questionnaire />}
+      {(afficheQuestionnaireV2 || afficheLesDeux) && (
+        <Questionnaire
+          etat={etatQuestionnaire.courant}
+          dispatch={dispatchQuestionnaire}
+          envoieDonneesFormulaire={envoieDonneesFormulaire}
+        />
+      )}
     </>
   );
 };

--- a/anssi-nis2-ui/src/Components/Simulateur/ChargeurEtape.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/ChargeurEtape.tsx
@@ -54,7 +54,8 @@ const ChargeurEtapeCalcule: DefaultComponent = () => {
       <Helmet>
         <title>
           MonEspaceNIS2 - Suis-je concerné ? -{" "}
-          {etatEtapes.contenuEtapeCourante.titre}
+          {afficheQuestionnaireV1 ? etatEtapes.contenuEtapeCourante.titre : ""}
+          {afficheQuestionnaireV2 ? etatEtapes.contenuEtapeCourante.titre : ""}
         </title>
       </Helmet>
       <div id="debutForm"></div>

--- a/anssi-nis2-ui/src/Components/Simulateur/ChargeurEtape.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/ChargeurEtape.tsx
@@ -15,6 +15,7 @@ import {
   etatParDefaut,
   reducerQuestionnaire,
 } from "../../questionnaire/reducerQuestionnaire.ts";
+import { TitresEtapes } from "./TitresEtapes.ts";
 
 const ChargeurEtapeCalcule: DefaultComponent = () => {
   const [donneesFormulaireSimulateur, propageActionSimulateur] = useReducer(
@@ -55,7 +56,9 @@ const ChargeurEtapeCalcule: DefaultComponent = () => {
         <title>
           MonEspaceNIS2 - Suis-je concerné ? -{" "}
           {afficheQuestionnaireV1 ? etatEtapes.contenuEtapeCourante.titre : ""}
-          {afficheQuestionnaireV2 ? etatEtapes.contenuEtapeCourante.titre : ""}
+          {afficheQuestionnaireV2
+            ? TitresEtapes[etatQuestionnaire.courant.etapeCourante]
+            : ""}
         </title>
       </Helmet>
       <div id="debutForm"></div>

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeActivites.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeActivites.tsx
@@ -13,6 +13,7 @@ import { libellesActivites } from "../../../References/LibellesActivites.ts";
 import { listeDescriptionsActivites } from "../../../References/ListeDescriptionsActivites.ts";
 import { Activite } from "anssi-nis2-core/src/Domain/Simulateur/Activite.definitions.ts";
 import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 type SecteurAvecActivite = SecteurSimple | SousSecteurActivite;
 type StateDeReponse = Partial<Record<SecteurAvecActivite, Activite[]>>;
@@ -47,7 +48,7 @@ export function EtapeActivites({
       <Stepper
         currentStep={6}
         stepCount={6}
-        title="Activités pratiquées"
+        title={TitresEtapes["activites"]}
         className="fr-mb-5w"
       />
       <hr className="fr-pb-5w" />

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeAppartenanceUE.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeAppartenanceUE.tsx
@@ -5,6 +5,7 @@ import BlocPrincipal from "../../BlocPrincipal.tsx";
 import { FormSimulateur } from "../Etapes";
 import { AppartenancePaysUnionEuropeenne } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 export const EtapeAppartenanceUE = ({
   onValider,
@@ -20,7 +21,7 @@ export const EtapeAppartenanceUE = ({
       <Stepper
         currentStep={2}
         stepCount={6}
-        title="Localisation de l'activité"
+        title={TitresEtapes["appartenanceUnionEuropeenne"]}
         className="fr-mb-5w"
       />
       <hr className="fr-pb-5w" />

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeDesignation.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeDesignation.tsx
@@ -5,6 +5,7 @@ import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import { DesignationOperateurServicesEssentiels } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { useState } from "react";
 import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 export const EtapeDesignation = ({
   onValider,
@@ -20,7 +21,7 @@ export const EtapeDesignation = ({
       <Stepper
         currentStep={1}
         stepCount={6}
-        title="Désignation éventuelle"
+        title={TitresEtapes["designationOperateurServicesEssentiels"]}
         className="fr-mb-5w"
       />
       <hr className="fr-pb-5w" />

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx
@@ -6,6 +6,7 @@ import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import { AppartenancePaysUnionEuropeenne } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
 import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 type StateDeReponse = {
   paysDecision: AppartenancePaysUnionEuropeenne[];
@@ -38,7 +39,7 @@ export function EtapeLocalisationEtablissementPrincipal({
       <Stepper
         currentStep={6}
         stepCount={6}
-        title="Localisation de votre activité"
+        title={TitresEtapes["localisationEtablissementPrincipal"]}
         className="fr-mb-5w"
       />
       <hr className="fr-pb-5w" />

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx
@@ -5,6 +5,7 @@ import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { useState } from "react";
 import { AppartenancePaysUnionEuropeenne } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 export function EtapeLocalisationServicesNumeriques({
   onValider,
@@ -28,7 +29,7 @@ export function EtapeLocalisationServicesNumeriques({
       <Stepper
         currentStep={6}
         stepCount={6}
-        title="Localisation de votre activité"
+        title={TitresEtapes["localisationFournitureServicesNumeriques"]}
         className="fr-mb-5w"
       />
       <hr className="fr-pb-5w" />

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapePrealable.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapePrealable.tsx
@@ -1,10 +1,11 @@
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import ImageLocalisation from "../../../assets/localisation-france.svg";
 import BlocPrincipal from "../../BlocPrincipal.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 export const EtapePrealable = ({ onValider }: { onValider: () => void }) => (
   <BlocPrincipal className="fond-gris" id="prealable">
-    <h2>Pour bien débuter</h2>
+    <h2>{TitresEtapes["prealable"]}</h2>
     <div className="conteneur-description">
       <div className="conteneur-paragraphes">
         <p>

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSecteursActivite.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSecteursActivite.tsx
@@ -6,6 +6,7 @@ import { libellesSecteursActivite } from "../../../References/LibellesSecteursAc
 import { useState } from "react";
 import { SecteurActivite } from "anssi-nis2-core/src/Domain/Simulateur/SecteurActivite.definitions.ts";
 import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 export const EtapeSecteursActivite = ({
   onValider,
@@ -21,7 +22,7 @@ export const EtapeSecteursActivite = ({
       <Stepper
         currentStep={5}
         stepCount={6}
-        title="Secteurs d'activité"
+        title={TitresEtapes["secteursActivite"]}
         className="fr-mb-5w"
       />
       <hr className="fr-pb-5w" />

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSousSecteursActivite.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeSousSecteursActivite.tsx
@@ -12,6 +12,7 @@ import { libellesSousSecteursActivite } from "../../../References/LibellesSousSe
 import { useState } from "react";
 import { SousSecteurActivite } from "anssi-nis2-core/src/Domain/Simulateur/SousSecteurActivite.definitions.ts";
 import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 export function EtapeSousSecteursActivite({
   secteursChoisis,
@@ -51,7 +52,7 @@ export function EtapeSousSecteursActivite({
       <Stepper
         currentStep={5}
         stepCount={6}
-        title="Sous-secteurs d'activité"
+        title={TitresEtapes["sousSecteursActivite"]}
         className="fr-mb-5w"
       />
       <hr className="fr-pb-5w" />

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTailleEntitePrivee.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTailleEntitePrivee.tsx
@@ -8,6 +8,7 @@ import {
   TrancheNombreEmployes,
 } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 export function EtapeTailleEntitePrivee({
   onValider,
@@ -31,7 +32,7 @@ export function EtapeTailleEntitePrivee({
       <Stepper
         currentStep={4}
         stepCount={6}
-        title="Taille de l'organisation"
+        title={TitresEtapes["tailleEntitePrivee"]}
         className="fr-mb-5w"
       />
       <hr className="fr-pb-5w" />

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTypeStructure.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeTypeStructure.tsx
@@ -5,6 +5,7 @@ import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import { useState } from "react";
 import { TypeStructure } from "anssi-nis2-core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { PrecedentSuivant } from "../PrecedentSuivant.tsx";
+import { TitresEtapes } from "../TitresEtapes.ts";
 
 export const EtapeTypeStructure = ({
   onValider,
@@ -20,7 +21,7 @@ export const EtapeTypeStructure = ({
       <Stepper
         currentStep={3}
         stepCount={6}
-        title="Type de structure"
+        title={TitresEtapes["typeStructure"]}
         className="fr-mb-5w"
       />
       <hr className="fr-pb-5w" />

--- a/anssi-nis2-ui/src/Components/Simulateur/TitresEtapes.ts
+++ b/anssi-nis2-ui/src/Components/Simulateur/TitresEtapes.ts
@@ -1,0 +1,15 @@
+import { TypeEtape } from "anssi-nis2-core/src/Domain/Simulateur/InformationsEtape.ts";
+
+export const TitresEtapes: Partial<Record<TypeEtape, string>> = {
+  activites: "Activités pratiquées",
+  appartenanceUnionEuropeenne: "Localisation de l'activité",
+  designationOperateurServicesEssentiels: "Désignation éventuelle",
+  localisationEtablissementPrincipal: "Localisation de votre activité",
+  localisationFournitureServicesNumeriques: "Localisation de votre activité",
+  prealable: "Pour bien débuter",
+  secteursActivite: "Secteurs d'activité",
+  sousSecteursActivite: "Sous-secteurs d'activité",
+  resultat: "Résultat",
+  tailleEntitePrivee: "Taille de l'organisation",
+  typeStructure: "Type de structure",
+};


### PR DESCRIPTION
### Contexte
Le questionnaire v2 va remplacer le v1 en PROD.
Mais il ne prenait pas en charge les titres de page `<title>`.

### PR
Cette PR synchronise le titre de la page avec l'étape courante gérée par `reducerQuestionnaire`.

![image](https://github.com/betagouv/anssi-nis2/assets/24898521/de9cf637-569f-430b-b838-c0ec3b297e42)
