### PR TITLE
Réparation du scroll vers le haut du formulaire

### DIFF
--- a/anssi-nis2-ui/src/Components/Simulateur/PrecedentSuivant.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/PrecedentSuivant.tsx
@@ -1,4 +1,5 @@
 import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { centreSurHautFormulaire } from "./scroll.ts";
 
 export function PrecedentSuivant(props: {
   message: string;
@@ -40,8 +41,3 @@ export function PrecedentSuivant(props: {
     </div>
   );
 }
-
-const centreSurHautFormulaire = () => {
-  const debut = document.getElementById("debutForm");
-  debut?.scrollIntoView({ behavior: "smooth" });
-};

--- a/anssi-nis2-ui/src/Components/Simulateur/PrecedentSuivant.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/PrecedentSuivant.tsx
@@ -41,5 +41,7 @@ export function PrecedentSuivant(props: {
   );
 }
 
-const centreSurHautFormulaire = () =>
-  window.scrollTo({ top: document.getElementById("debutForm")?.offsetTop });
+const centreSurHautFormulaire = () => {
+  const debut = document.getElementById("debutForm");
+  debut?.scrollIntoView({ behavior: "smooth" });
+};

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -31,6 +31,7 @@ import { EtapeLocalisationServicesNumeriques } from "./EtapesRefacto/EtapeLocali
 import { EtapeLocalisationEtablissementPrincipal } from "./EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx";
 import { AidezNousAmeliorerService } from "../AidezNousAmeliorerService.tsx";
 import { EnvoieDonneesFormulaire } from "../../Services/Simulateur/Operations/appelsApi";
+import { centreSurHautFormulaire } from "./scroll.ts";
 
 export const Questionnaire = ({
   etat,
@@ -44,7 +45,12 @@ export const Questionnaire = ({
   switch (etat.etapeCourante) {
     case "prealable":
       return (
-        <EtapePrealable onValider={() => dispatch(valideEtapePrealable())} />
+        <EtapePrealable
+          onValider={() => {
+            dispatch(valideEtapePrealable());
+            centreSurHautFormulaire();
+          }}
+        />
       );
 
     case "designationOperateurServicesEssentiels":

--- a/anssi-nis2-ui/src/Components/Simulateur/scroll.ts
+++ b/anssi-nis2-ui/src/Components/Simulateur/scroll.ts
@@ -1,0 +1,4 @@
+export const centreSurHautFormulaire = () => {
+  const debut = document.getElementById("debutForm");
+  debut?.scrollIntoView({ behavior: "smooth" });
+};


### PR DESCRIPTION
Le scroll vers le haut était assez « random » dans son comportement.

En utilisant [`scrollIntoView`](https://developer.mozilla.org/fr/docs/Web/API/Element/scrollIntoView) le comportement est déterministe.