### PR TITLE
Branchement de l'inscription utilisateur à l'API Brevo

### DIFF
--- a/anssi-nis2-api/.env.template
+++ b/anssi-nis2-api/.env.template
@@ -44,5 +44,9 @@ LIMITATION_REQUETES_LONGUE_NOMBRE=
 SENTRY_DSN=
 SENTRY_ENVIRONNEMENT=
 
+# Brevo
+BREVO_CLE_API= # Clé d'API pour appeler Brevo.
+BREVO_API_BASE_URL= # URL de base de l'API Brevo. Exemple : https://api.brevo.com/v3
+
 # Filtrage IP
 ADRESSES_IP_AUTORISEES= # IP autorisées, séparées par des virgules (si plusieurs). Laisser vide pour désactiver le filtrage

--- a/anssi-nis2-api/.env.template
+++ b/anssi-nis2-api/.env.template
@@ -45,7 +45,7 @@ SENTRY_DSN=
 SENTRY_ENVIRONNEMENT=
 
 # Brevo
-BREVO_CLE_API= # Clé d'API pour appeler Brevo.
+BREVO_CLE_API= # Clé d'API pour appeler Brevo. Laisser vide pour ne pas utiliser Brevo (une implémentation in-memory sera utilisée à la place).
 BREVO_API_BASE_URL= # URL de base de l'API Brevo. Exemple : https://api.brevo.com/v3
 
 # Filtrage IP

--- a/anssi-nis2-api/package.json
+++ b/anssi-nis2-api/package.json
@@ -20,6 +20,7 @@
     "typeorm": "typeorm-ts-node-commonjs"
   },
   "dependencies": {
+    "@nestjs/axios": "^3.0.2",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
@@ -28,6 +29,7 @@
     "@nestjs/serve-static": "^4.0.0",
     "@nestjs/throttler": "^5.0.0",
     "@nestjs/typeorm": "^10.0.0",
+    "axios": "^1.6.8",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "dotenv": "^16.3.1",

--- a/anssi-nis2-api/src/app.module.ts
+++ b/anssi-nis2-api/src/app.module.ts
@@ -1,26 +1,22 @@
-import {
-  Logger,
-  Module,
-} from "@nestjs/common";
-import {ConfigModule} from "@nestjs/config";
-import {ThrottlerModule} from "@nestjs/throttler";
-import {TypeOrmModule} from "@nestjs/typeorm";
-import {SentryModule} from "@ntegral/nestjs-sentry";
-import {DataSource} from "typeorm";
-import {optionsThrottlerModuleAsync} from "./configurationThrottler";
-import {fabriqueAsynchroneOptionsServeurStatique} from "./Fabriques/fabriqueAsynchroneOptionsServeurStatique";
+import { Logger, Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { ThrottlerModule } from "@nestjs/throttler";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { SentryModule } from "@ntegral/nestjs-sentry";
+import { DataSource } from "typeorm";
+import { optionsThrottlerModuleAsync } from "./configurationThrottler";
+import { fabriqueAsynchroneOptionsServeurStatique } from "./Fabriques/fabriqueAsynchroneOptionsServeurStatique";
 import {
   fabriqueAsynchroneOptionsTypeOrm,
   fabriqueAsynchroneOptionsTypeOrmJournal,
 } from "./Fabriques/fabriqueAsynchroneOptionsTypeOrm";
-import {InformationsEmailsModule} from "./informations-emails/informations-emails.module";
+import { InformationsEmailsModule } from "./informations-emails/informations-emails.module";
 import { ServeurStatiqueConfigurableModule } from "./intergiciels/serveur-statique-configurable/serveur-statique-configurable.module";
-import {JournalModule} from "./journal/journal.module";
-import {optionsSentryModule, sentryIntercepteur} from "./optionsSentryModule";
-import {SimulateurReponseModule} from "./simulateur-reponse/simulateur-reponse.module";
+import { JournalModule } from "./journal/journal.module";
+import { optionsSentryModule, sentryIntercepteur } from "./optionsSentryModule";
+import { SimulateurReponseModule } from "./simulateur-reponse/simulateur-reponse.module";
 
 const optionsConnectionBaseDeDonnees = fabriqueAsynchroneOptionsTypeOrm();
-
 
 @Module({
   imports: [
@@ -32,9 +28,7 @@ const optionsConnectionBaseDeDonnees = fabriqueAsynchroneOptionsTypeOrm();
     ),
     SimulateurReponseModule,
     JournalModule,
-    ConfigModule.forRoot({
-      isGlobal: true,
-    }),
+    ConfigModule.forRoot({ isGlobal: true }),
     InformationsEmailsModule,
     SentryModule.forRootAsync(optionsSentryModule),
   ],

--- a/anssi-nis2-api/src/informations-emails/crm.InMemory.ts
+++ b/anssi-nis2-api/src/informations-emails/crm.InMemory.ts
@@ -1,4 +1,5 @@
 import { Crm } from "./crm";
+import { CreeInformationsEmailDto } from "./dto/cree-informations-email.dto";
 
 export class CrmInMemory extends Crm {
   public inscrits: string[] = [];
@@ -9,7 +10,11 @@ export class CrmInMemory extends Crm {
     this.avecLog = activeLeLog;
   }
 
-  async inscrisUtilisateur(email: string): Promise<void> {
+  async inscrisUtilisateur(
+    inscription: CreeInformationsEmailDto,
+  ): Promise<void> {
+    const { email } = inscription;
+
     if (this.avecLog) console.log(`[CRM In-Memory] Nouvel inscrit : ${email}`);
 
     this.inscrits.push(email);

--- a/anssi-nis2-api/src/informations-emails/crm.InMemory.ts
+++ b/anssi-nis2-api/src/informations-emails/crm.InMemory.ts
@@ -1,0 +1,17 @@
+import { Crm } from "./crm";
+
+export class CrmInMemory extends Crm {
+  public inscrits: string[] = [];
+  private readonly avecLog: boolean;
+
+  constructor({ activeLeLog }: { activeLeLog: boolean }) {
+    super();
+    this.avecLog = activeLeLog;
+  }
+
+  async inscrisUtilisateur(email: string): Promise<void> {
+    if (this.avecLog) console.log(`[CRM In-Memory] Nouvel inscrit : ${email}`);
+
+    this.inscrits.push(email);
+  }
+}

--- a/anssi-nis2-api/src/informations-emails/crm.brevo.ts
+++ b/anssi-nis2-api/src/informations-emails/crm.brevo.ts
@@ -1,0 +1,26 @@
+import { Crm } from "./crm";
+import { HttpService } from "@nestjs/axios";
+
+export class CrmBrevo extends Crm {
+  constructor(
+    private readonly http: HttpService,
+    private readonly baseUrl: string,
+    private readonly cleApi: string,
+  ) {
+    super();
+  }
+
+  async inscrisUtilisateur(email: string): Promise<void> {
+    await this.http.axiosRef.post(
+      `${this.baseUrl}/contacts`,
+      { email },
+      {
+        headers: {
+          "api-key": this.cleApi,
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+      },
+    );
+  }
+}

--- a/anssi-nis2-api/src/informations-emails/crm.brevo.ts
+++ b/anssi-nis2-api/src/informations-emails/crm.brevo.ts
@@ -16,7 +16,10 @@ export class CrmBrevo extends Crm {
   ): Promise<void> {
     await this.http.axiosRef.post(
       `${this.baseUrl}/contacts`,
-      { email: inscription.email },
+      {
+        email: inscription.email,
+        emailBlacklisted: !inscription.accepteInfolettreNis2,
+      },
       {
         headers: {
           "api-key": this.cleApi,

--- a/anssi-nis2-api/src/informations-emails/crm.brevo.ts
+++ b/anssi-nis2-api/src/informations-emails/crm.brevo.ts
@@ -19,6 +19,7 @@ export class CrmBrevo extends Crm {
       {
         email: inscription.email,
         emailBlacklisted: !inscription.accepteInfolettreNis2,
+        attributes: { ORGANISATION: inscription.nomOrganisation },
       },
       {
         headers: {

--- a/anssi-nis2-api/src/informations-emails/crm.brevo.ts
+++ b/anssi-nis2-api/src/informations-emails/crm.brevo.ts
@@ -1,5 +1,6 @@
 import { Crm } from "./crm";
 import { HttpService } from "@nestjs/axios";
+import { CreeInformationsEmailDto } from "./dto/cree-informations-email.dto";
 
 export class CrmBrevo extends Crm {
   constructor(
@@ -10,10 +11,12 @@ export class CrmBrevo extends Crm {
     super();
   }
 
-  async inscrisUtilisateur(email: string): Promise<void> {
+  async inscrisUtilisateur(
+    inscription: CreeInformationsEmailDto,
+  ): Promise<void> {
     await this.http.axiosRef.post(
       `${this.baseUrl}/contacts`,
-      { email },
+      { email: inscription.email },
       {
         headers: {
           "api-key": this.cleApi,

--- a/anssi-nis2-api/src/informations-emails/crm.ts
+++ b/anssi-nis2-api/src/informations-emails/crm.ts
@@ -1,0 +1,6 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export abstract class Crm {
+  abstract inscrisUtilisateur(email: string): Promise<void>;
+}

--- a/anssi-nis2-api/src/informations-emails/crm.ts
+++ b/anssi-nis2-api/src/informations-emails/crm.ts
@@ -1,6 +1,9 @@
 import { Injectable } from "@nestjs/common";
+import { CreeInformationsEmailDto } from "./dto/cree-informations-email.dto";
 
 @Injectable()
 export abstract class Crm {
-  abstract inscrisUtilisateur(email: string): Promise<void>;
+  abstract inscrisUtilisateur(
+    inscription: CreeInformationsEmailDto,
+  ): Promise<void>;
 }

--- a/anssi-nis2-api/src/informations-emails/informations-emails.controller.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.controller.ts
@@ -9,7 +9,7 @@ export class InformationsEmailsController {
   ) {}
 
   @Post()
-  async ajoute(@Body() creeInformationsEmailDto: CreeInformationsEmailDto) {
-    return this.informationsEmailsService.ajoute(creeInformationsEmailDto);
+  async ajoute(@Body() inscription: CreeInformationsEmailDto) {
+    return this.informationsEmailsService.ajoute(inscription);
   }
 }

--- a/anssi-nis2-api/src/informations-emails/informations-emails.module.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.module.ts
@@ -4,13 +4,24 @@ import { InformationsEmailsController } from "./informations-emails.controller";
 import { InformationsEmail } from "./entities/informations-email.entity";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { Crm } from "./crm";
-import { CrmInMemory } from "./crm.InMemory";
+import { CrmBrevo } from "./crm.brevo";
+import { HttpModule, HttpService } from "@nestjs/axios";
+import { ConfigService } from "@nestjs/config";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([InformationsEmail])],
+  imports: [TypeOrmModule.forFeature([InformationsEmail]), HttpModule],
   providers: [
     InformationsEmailsService,
-    { provide: Crm, useValue: new CrmInMemory({ activeLeLog: true }) },
+    {
+      provide: Crm,
+      inject: [ConfigService, HttpService],
+      useFactory: (config: ConfigService, http: HttpService) =>
+        new CrmBrevo(
+          http,
+          config.get("BREVO_API_BASE_URL"),
+          config.get("BREVO_CLE_API"),
+        ),
+    },
   ],
   controllers: [InformationsEmailsController],
 })

--- a/anssi-nis2-api/src/informations-emails/informations-emails.module.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.module.ts
@@ -7,6 +7,7 @@ import { Crm } from "./crm";
 import { CrmBrevo } from "./crm.brevo";
 import { HttpModule, HttpService } from "@nestjs/axios";
 import { ConfigService } from "@nestjs/config";
+import { CrmInMemory } from "./crm.InMemory";
 
 @Module({
   imports: [TypeOrmModule.forFeature([InformationsEmail]), HttpModule],
@@ -15,12 +16,12 @@ import { ConfigService } from "@nestjs/config";
     {
       provide: Crm,
       inject: [ConfigService, HttpService],
-      useFactory: (config: ConfigService, http: HttpService) =>
-        new CrmBrevo(
-          http,
-          config.get("BREVO_API_BASE_URL"),
-          config.get("BREVO_CLE_API"),
-        ),
+      useFactory: (config: ConfigService, http: HttpService) => {
+        const cleApi = config.get("BREVO_CLE_API");
+        return cleApi
+          ? new CrmBrevo(http, config.get("BREVO_API_BASE_URL"), cleApi)
+          : new CrmInMemory({ activeLeLog: true });
+      },
     },
   ],
   controllers: [InformationsEmailsController],

--- a/anssi-nis2-api/src/informations-emails/informations-emails.module.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.module.ts
@@ -3,10 +3,15 @@ import { InformationsEmailsService } from "./informations-emails.service";
 import { InformationsEmailsController } from "./informations-emails.controller";
 import { InformationsEmail } from "./entities/informations-email.entity";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { Crm } from "./crm";
+import { CrmInMemory } from "./crm.InMemory";
 
 @Module({
   imports: [TypeOrmModule.forFeature([InformationsEmail])],
-  providers: [InformationsEmailsService],
+  providers: [
+    InformationsEmailsService,
+    { provide: Crm, useValue: new CrmInMemory({ activeLeLog: true }) },
+  ],
   controllers: [InformationsEmailsController],
 })
 export class InformationsEmailsModule {}

--- a/anssi-nis2-api/src/informations-emails/informations-emails.service.spec.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.service.spec.ts
@@ -18,11 +18,11 @@ describe("InformationsEmailsService", () => {
   });
 
   it("ajoute les donnees dans la base mockée", async () => {
-    const mockModule = await testingModuleBuilder.compile();
-    const srv = mockModule.get<InformationsEmailsService>(
-      InformationsEmailsService,
-    );
-    const reponse = await srv.ajoute(informationsEmail);
+    const module = await testingModuleBuilder.compile();
+    const service = module.get(InformationsEmailsService);
+
+    const reponse = await service.ajoute(informationsEmail);
+
     espereEmailsInformationCorrespondASonDto(reponse, informationsEmail);
   });
 });

--- a/anssi-nis2-api/src/informations-emails/informations-emails.service.spec.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.service.spec.ts
@@ -1,15 +1,10 @@
 import { InformationsEmailsService } from "./informations-emails.service";
 import { mockInformationsEmailRepository } from "./informations-emails.repository.mock";
 import { informationsEmail } from "./example/informations.email.exemples";
-import {
-  espereEmailsInformationCorrespondASonDto,
-  serviceConfigurationPourTests,
-} from "../test/utilitaires/facilitateurs";
+import { espereEmailsInformationCorrespondASonDto } from "../test/utilitaires/facilitateurs";
 import { InformationsEmail } from "./entities/informations-email.entity";
 import { Test } from "@nestjs/testing";
-import { getRepositoryToken, TypeOrmModule } from "@nestjs/typeorm";
-import { fabriqueAsynchroneOptionsTypeOrm } from "../Fabriques/fabriqueAsynchroneOptionsTypeOrm";
-import { ConfigModule } from "@nestjs/config";
+import { getRepositoryToken } from "@nestjs/typeorm";
 
 describe("InformationsEmailsService", () => {
   const testingModuleBuilder = Test.createTestingModule({
@@ -23,44 +18,6 @@ describe("InformationsEmailsService", () => {
   });
 
   it("ajoute les donnees dans la base mockée", async () => {
-    const mockModule = await testingModuleBuilder.compile();
-    const srv = mockModule.get<InformationsEmailsService>(
-      InformationsEmailsService,
-    );
-    const reponse = await srv.ajoute(informationsEmail);
-    espereEmailsInformationCorrespondASonDto(reponse, informationsEmail);
-  });
-  // Suppression pour des raisons de bug dans l'API : impossiuble d'ajouter dans
-  //  la base avec des validations
-  it.skip("n'autorise pas l'ajout de donn'ees avec un email mal formé", async () => {
-    const mockModule = await testingModuleBuilder.compile();
-    const informationEmailService = mockModule.get<InformationsEmailsService>(
-      InformationsEmailsService,
-    );
-    const informationsEmailInvalide = {
-      ...informationsEmail,
-      email: "INVALIDE",
-    };
-    await expect(
-      informationEmailService.ajoute(informationsEmailInvalide),
-    ).rejects.toThrow();
-  });
-});
-
-describe.skip("InformationsEmailsService sur vraie DB", () => {
-  const testingModuleBuilder = Test.createTestingModule({
-    controllers: [],
-    imports: [
-      TypeOrmModule.forRootAsync(fabriqueAsynchroneOptionsTypeOrm()),
-      TypeOrmModule.forFeature([InformationsEmail]),
-      ConfigModule.forRoot({
-        isGlobal: true,
-      }),
-    ],
-    providers: [...[serviceConfigurationPourTests, InformationsEmailsService]],
-  });
-
-  it("ajoute les donnees dans la base réelle", async () => {
     const mockModule = await testingModuleBuilder.compile();
     const srv = mockModule.get<InformationsEmailsService>(
       InformationsEmailsService,

--- a/anssi-nis2-api/src/informations-emails/informations-emails.service.spec.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.service.spec.ts
@@ -3,26 +3,55 @@ import { mockInformationsEmailRepository } from "./informations-emails.repositor
 import { informationsEmail } from "./example/informations.email.exemples";
 import { espereEmailsInformationCorrespondASonDto } from "../test/utilitaires/facilitateurs";
 import { InformationsEmail } from "./entities/informations-email.entity";
-import { Test } from "@nestjs/testing";
+import { Test, TestingModuleBuilder } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
+import { Crm } from "./crm";
+import { CrmInMemory } from "./crm.InMemory";
 
 describe("InformationsEmailsService", () => {
-  const testingModuleBuilder = Test.createTestingModule({
-    providers: [
-      {
-        provide: getRepositoryToken(InformationsEmail),
-        useValue: mockInformationsEmailRepository,
-      },
-      InformationsEmailsService,
-    ],
+  let testingModuleBuilder: TestingModuleBuilder;
+  let crmInMemory: CrmInMemory;
+
+  beforeEach(() => {
+    crmInMemory = new CrmInMemory({ activeLeLog: false });
+
+    testingModuleBuilder = Test.createTestingModule({
+      providers: [
+        {
+          provide: getRepositoryToken(InformationsEmail),
+          useValue: mockInformationsEmailRepository,
+        },
+        { provide: Crm, useValue: crmInMemory },
+        InformationsEmailsService,
+      ],
+    });
   });
 
-  it("ajoute les donnees dans la base mockée", async () => {
+  const fabriqueService = async () => {
     const module = await testingModuleBuilder.compile();
-    const service = module.get(InformationsEmailsService);
+    return module.get(InformationsEmailsService);
+  };
+
+  it("ajoute les données dans la base mockée", async () => {
+    const service = await fabriqueService();
 
     const reponse = await service.ajoute(informationsEmail);
 
     espereEmailsInformationCorrespondASonDto(reponse, informationsEmail);
   });
+
+  it("ajoute le nouvel inscrit au CRM", async () => {
+    const service = await fabriqueService();
+
+    await service.ajoute({
+      ...informationsEmail,
+      email: "utilisateur@societe.fr",
+    });
+
+    expect(crmInMemory.inscrits).toContain("utilisateur@societe.fr");
+  });
+
+  it.todo(
+    "enregistre le nom de l'organisation s'il est présent (cas de l'inscription après le test)",
+  );
 });

--- a/anssi-nis2-api/src/informations-emails/informations-emails.service.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.service.ts
@@ -17,17 +17,13 @@ export class InformationsEmailsService {
   ) {}
 
   async ajoute(
-    creeInformationsEmailDto: CreeInformationsEmailDto,
+    inscription: CreeInformationsEmailDto,
   ): Promise<InformationsEmail> {
-    this.logger.debug(
-      `Ajout d'un email : ${JSON.stringify(creeInformationsEmailDto)}`,
-    );
+    this.logger.debug(`Ajout d'un email : ${JSON.stringify(inscription)}`);
 
-    const infos = await this.informationsEmailRepository.save(
-      creeInformationsEmailDto,
-    );
+    const infos = await this.informationsEmailRepository.save(inscription);
 
-    await this.crm.inscrisUtilisateur(creeInformationsEmailDto.email);
+    await this.crm.inscrisUtilisateur(inscription.email);
 
     return infos;
   }

--- a/anssi-nis2-api/src/informations-emails/informations-emails.service.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { CreeInformationsEmailDto } from "./dto/cree-informations-email.dto";
 import { InformationsEmail } from "./entities/informations-email.entity";
 import { Repository } from "typeorm";
 import { InjectRepository } from "@nestjs/typeorm";
+import { Crm } from "./crm";
 
 @Injectable()
 export class InformationsEmailsService {
@@ -11,6 +12,8 @@ export class InformationsEmailsService {
   constructor(
     @InjectRepository(InformationsEmail)
     private informationsEmailRepository: Repository<InformationsEmail>,
+    @Inject(Crm)
+    private crm: Crm,
   ) {}
 
   async ajoute(
@@ -19,6 +22,13 @@ export class InformationsEmailsService {
     this.logger.debug(
       `Ajout d'un email : ${JSON.stringify(creeInformationsEmailDto)}`,
     );
-    return this.informationsEmailRepository.save(creeInformationsEmailDto);
+
+    const infos = await this.informationsEmailRepository.save(
+      creeInformationsEmailDto,
+    );
+
+    await this.crm.inscrisUtilisateur(creeInformationsEmailDto.email);
+
+    return infos;
   }
 }

--- a/anssi-nis2-api/src/informations-emails/informations-emails.service.ts
+++ b/anssi-nis2-api/src/informations-emails/informations-emails.service.ts
@@ -23,7 +23,7 @@ export class InformationsEmailsService {
 
     const infos = await this.informationsEmailRepository.save(inscription);
 
-    await this.crm.inscrisUtilisateur(inscription.email);
+    await this.crm.inscrisUtilisateur(inscription);
 
     return infos;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       "version": "0.0.1",
       "license": "See LICENSE file",
       "dependencies": {
+        "@nestjs/axios": "^3.0.2",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.0.0",
@@ -52,6 +53,7 @@
         "@nestjs/serve-static": "^4.0.0",
         "@nestjs/throttler": "^5.0.0",
         "@nestjs/typeorm": "^10.0.0",
+        "axios": "^1.6.8",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "dotenv": "^16.3.1",
@@ -320,9 +322,7 @@
         "remark-frontmatter": "^5.0.0",
         "remark-yaml-config": "^7.0.0",
         "ts-pattern": "^5.0.5",
-        "tss-react": "^4.8.8",
-        "unified": "^11.0.4",
-        "yaml": "^2.3.4"
+        "tss-react": "^4.8.8"
       },
       "devDependencies": {
         "@storybook/addon-coverage": "^1.0.0",
@@ -371,14 +371,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "anssi-nis2-ui/node_modules/yaml": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "commun/core": {
@@ -5136,6 +5128,16 @@
         "gunzip-maybe": "^1.4.2",
         "pump": "^3.0.0",
         "tar-fs": "^2.1.1"
+      }
+    },
+    "node_modules/@nestjs/axios": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-3.0.2.tgz",
+      "integrity": "sha512-Z6GuOUdNQjP7FX+OuV2Ybyamse+/e0BFdTWBX5JxpBDKA+YkdLynDgG6HTF04zy6e9zPa19UX0WA2VDoehwhXQ==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "axios": "^1.3.1",
+        "rxjs": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -12402,11 +12404,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -15942,9 +15944,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
### Contexte
On veut utiliser Brevo comme CRM.

### PR
Cette PR ajoute un adaptateur qui sait envoyer les emails récoltés à Brevo.

> [!IMPORTANT]
> Deux variables d'environnement à créer : `BREVO_CLE_API` & `BREVO_API_BASE_URL`
> Il faut créer l'attribut `ORGANISATION` sur les contacts Brevo