### PR TITLE
Préparation de l'affichage « v2 » des résultats

### DIFF
--- a/anssi-nis2-ui/.env.template
+++ b/anssi-nis2-ui/.env.template
@@ -9,3 +9,4 @@ VITE_SENTRY_ENVIRONNEMENT=
 # Support utilisateur via Crisp
 VITE_CRISP_URL_FAQ= # URL vers la FAQ Crisp. Laisser vide pour masquer le lien vers la FAQ.
 
+VITE_VERSION_ETAPE_RESULTAT= # Version de l'étape Résultat à afficher. `v1`, `v2` ou `all`. Valeur par défaut : `v1`.

--- a/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
@@ -2,7 +2,30 @@ import { EtatQuestionnaire } from "../../questionnaire/reducerQuestionnaire.ts";
 import { EtapeResultat } from "./EtapesRefacto/EtapeResultat.tsx";
 
 export function AiguilleVersEtapeResultat(props: {
+  version: string;
   reponses: EtatQuestionnaire;
 }) {
-  return <EtapeResultat reponses={props.reponses} />;
+  const afficheV1 = props.version === "v1";
+  const afficheV2 = props.version === "v2";
+  const afficheLesDeux = props.version === "all";
+
+  if (afficheV1) return <EtapeResultat reponses={props.reponses} />;
+  if (afficheV2) return <EtapeResultatV2 />;
+
+  if (afficheLesDeux)
+    return (
+      <>
+        <EtapeResultat reponses={props.reponses} />
+        <hr />
+        <EtapeResultatV2 />
+      </>
+    );
+}
+
+function EtapeResultatV2() {
+  return (
+    <div>
+      <h1>RÉSULTAT V2</h1>
+    </div>
+  );
 }

--- a/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
@@ -1,5 +1,6 @@
 import { EtatQuestionnaire } from "../../questionnaire/reducerQuestionnaire.ts";
 import { EtapeResultat } from "./EtapesRefacto/EtapeResultat.tsx";
+import { EtapeResultatV2 } from "./EtapeResultatV2.tsx";
 
 export function AiguilleVersEtapeResultat(props: {
   version: string;
@@ -20,12 +21,4 @@ export function AiguilleVersEtapeResultat(props: {
         <EtapeResultatV2 />
       </>
     );
-}
-
-function EtapeResultatV2() {
-  return (
-    <div>
-      <h1>RÉSULTAT V2</h1>
-    </div>
-  );
 }

--- a/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
@@ -1,0 +1,8 @@
+import { EtatQuestionnaire } from "../../questionnaire/reducerQuestionnaire.ts";
+import { EtapeResultat } from "./EtapesRefacto/EtapeResultat.tsx";
+
+export function AiguilleVersEtapeResultat(props: {
+  reponses: EtatQuestionnaire;
+}) {
+  return <EtapeResultat reponses={props.reponses} />;
+}

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapeResultatV2.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapeResultatV2.tsx
@@ -1,0 +1,7 @@
+export function EtapeResultatV2() {
+  return (
+    <div>
+      <h1>RÉSULTAT V2</h1>
+    </div>
+  );
+}

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeResultat.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeResultat.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from "react";
-import { EnvoieDonneesFormulaire } from "../../../Services/Simulateur/Operations/appelsApi";
 import { LigneResultat } from "../Resultats/LigneResultat.tsx";
 import { DonneesFormulaireSimulateur } from "anssi-nis2-core/src/Domain/Simulateur/services/DonneesFormulaire/DonneesFormulaire.definitions.ts";
 import { ConvertisseurDonneesBrutesVersEtatDonneesSimulateur } from "anssi-nis2-core/src/Domain/Simulateur/services/Eligibilite/ReponseEtat.fabriques.ts";
@@ -18,10 +16,8 @@ import { LigneReseauxSociaux } from "../Resultats/LigneReseauxSociaux.tsx";
 
 export const EtapeResultat = ({
   reponses,
-  persistance,
 }: {
   reponses: DonneesFormulaireSimulateur;
-  persistance: EnvoieDonneesFormulaire;
 }) => {
   const donneesReponse =
     ConvertisseurDonneesBrutesVersEtatDonneesSimulateur.depuisDonneesFormulaireSimulateur(
@@ -29,10 +25,6 @@ export const EtapeResultat = ({
     ) as EtatRegulation;
   const etatRegulation = evalueEtatRegulation(donneesReponse);
   const modeFormulaireEmail = getModeFormulaireEmail(etatRegulation.decision);
-
-  useEffect(() => {
-    persistance(reponses);
-  }, [persistance, reponses]);
 
   return (
     <>

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/PersisteReponsesDuQuestionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/PersisteReponsesDuQuestionnaire.tsx
@@ -1,0 +1,15 @@
+import { EnvoieDonneesFormulaire } from "../../../Services/Simulateur/Operations/appelsApi";
+import { EtatQuestionnaire } from "../../../questionnaire/reducerQuestionnaire.ts";
+import { ReactNode, useEffect } from "react";
+
+export function PersisteReponsesDuQuestionnaire(props: {
+  persistance: EnvoieDonneesFormulaire;
+  reponses: EtatQuestionnaire;
+  children: ReactNode;
+}) {
+  useEffect(() => {
+    props.persistance(props.reponses);
+  }, [props.persistance, props.reponses]);
+
+  return props.children;
+}

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -165,7 +165,10 @@ export const Questionnaire = ({
           reponses={etat}
           persistance={envoieDonneesFormulaire}
         >
-          <AiguilleVersEtapeResultat reponses={etat} />
+          <AiguilleVersEtapeResultat
+            version={import.meta.env.VITE_VERSION_ETAPE_RESULTAT || "v1"}
+            reponses={etat}
+          />
         </PersisteReponsesDuQuestionnaire>
       );
   }

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -25,7 +25,6 @@ import { EtapeTypeStructure } from "./EtapesRefacto/EtapeTypeStructure.tsx";
 import { EtapeTailleEntitePrivee } from "./EtapesRefacto/EtapeTailleEntitePrivee.tsx";
 import { EtapeSecteursActivite } from "./EtapesRefacto/EtapeSecteursActivite.tsx";
 import { EtapeSousSecteursActivite } from "./EtapesRefacto/EtapeSousSecteursActivite.tsx";
-import { EtapeResultat } from "./EtapesRefacto/EtapeResultat.tsx";
 import { EtapeActivites } from "./EtapesRefacto/EtapeActivites.tsx";
 import { EtapeLocalisationServicesNumeriques } from "./EtapesRefacto/EtapeLocalisationServicesNumeriques.tsx";
 import { EtapeLocalisationEtablissementPrincipal } from "./EtapesRefacto/EtapeLocalisationEtablissementPrincipal.tsx";
@@ -33,6 +32,7 @@ import { AidezNousAmeliorerService } from "../AidezNousAmeliorerService.tsx";
 import { EnvoieDonneesFormulaire } from "../../Services/Simulateur/Operations/appelsApi";
 import { centreSurHautFormulaire } from "./scroll.ts";
 import { PersisteReponsesDuQuestionnaire } from "./EtapesRefacto/PersisteReponsesDuQuestionnaire.tsx";
+import { AiguilleVersEtapeResultat } from "./AiguilleVersEtapeResultat.tsx";
 
 export const Questionnaire = ({
   etat,
@@ -165,7 +165,7 @@ export const Questionnaire = ({
           reponses={etat}
           persistance={envoieDonneesFormulaire}
         >
-          <EtapeResultat reponses={etat} />
+          <AiguilleVersEtapeResultat reponses={etat} />
         </PersisteReponsesDuQuestionnaire>
       );
   }

--- a/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/Questionnaire.tsx
@@ -32,6 +32,7 @@ import { EtapeLocalisationEtablissementPrincipal } from "./EtapesRefacto/EtapeLo
 import { AidezNousAmeliorerService } from "../AidezNousAmeliorerService.tsx";
 import { EnvoieDonneesFormulaire } from "../../Services/Simulateur/Operations/appelsApi";
 import { centreSurHautFormulaire } from "./scroll.ts";
+import { PersisteReponsesDuQuestionnaire } from "./EtapesRefacto/PersisteReponsesDuQuestionnaire.tsx";
 
 export const Questionnaire = ({
   etat,
@@ -160,7 +161,12 @@ export const Questionnaire = ({
 
     case "resultat":
       return (
-        <EtapeResultat reponses={etat} persistance={envoieDonneesFormulaire} />
+        <PersisteReponsesDuQuestionnaire
+          reponses={etat}
+          persistance={envoieDonneesFormulaire}
+        >
+          <EtapeResultat reponses={etat} />
+        </PersisteReponsesDuQuestionnaire>
       );
   }
 };

--- a/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/EtapeResultat.stories.tsx
+++ b/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/EtapeResultat.stories.tsx
@@ -26,7 +26,7 @@ const archetypeDonneesFormulaire = fabriqueDonneesFormulaire({
 const meta: Meta<typeof EtapeResultat> = {
   title: "Composants/Simulateur/Resultat",
   component: EtapeResultat,
-  args: { reponses: archetypeDonneesFormulaire, persistance: async () => {} },
+  args: { reponses: archetypeDonneesFormulaire },
 };
 
 export default meta;

--- a/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/EtapeResultatV2.stories.tsx
+++ b/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/EtapeResultatV2.stories.tsx
@@ -1,0 +1,10 @@
+import { Meta } from "@storybook/react";
+import { EtapeResultatV2 } from "../../../../Components/Simulateur/EtapeResultatV2.tsx";
+
+const meta: Meta<typeof EtapeResultatV2> = {
+  component: EtapeResultatV2,
+  title: "Composants/Simulateur/Resultat V2",
+};
+export default meta;
+
+export const Defaut = { args: {} };


### PR DESCRIPTION
Cette PR pose un aiguillage entre l'affichage legacy des résultats et l'affichage « v2 ».

Le but est de pouvoir développer l'affichage « v2 » sans impacter la PROD tant que ce n'est pas terminé.