### PR TITLE
Affichage de résultats dans `<EtapeResultatV2 />`

### DIFF
--- a/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
@@ -2,6 +2,7 @@ import { EtatQuestionnaire } from "../../questionnaire/reducerQuestionnaire.ts";
 import { EtapeResultat } from "./EtapesRefacto/EtapeResultat.tsx";
 import { EtapeResultatV2 } from "./EtapeResultatV2.tsx";
 import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions.ts";
+import { ReactElement } from "react";
 
 export function AiguilleVersEtapeResultat(props: {
   version: string;
@@ -11,17 +12,29 @@ export function AiguilleVersEtapeResultat(props: {
   const afficheV2 = props.version === "v2";
   const afficheLesDeux = props.version === "all";
 
+  const v2: ReactElement = (
+    <AvecEvaluationEligibilitie>
+      {(r: ResultatEligibilite) => <EtapeResultatV2 resultat={r} />}
+    </AvecEvaluationEligibilitie>
+  );
+
   if (afficheV1) return <EtapeResultat reponses={props.reponses} />;
-  if (afficheV2) return <EtapeResultatV2 resultat={fauxResultatReguleEE} />;
+  if (afficheV2) return v2;
 
   if (afficheLesDeux)
     return (
       <>
         <EtapeResultat reponses={props.reponses} />
         <hr />
-        <EtapeResultatV2 resultat={fauxResultatReguleEE} />
+        {v2}
       </>
     );
+}
+
+function AvecEvaluationEligibilitie(props: {
+  children: (r: ResultatEligibilite) => ReactElement;
+}) {
+  return props.children(fauxResultatReguleEE);
 }
 
 const fauxResultatReguleEE: ResultatEligibilite = {

--- a/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
@@ -1,6 +1,7 @@
 import { EtatQuestionnaire } from "../../questionnaire/reducerQuestionnaire.ts";
 import { EtapeResultat } from "./EtapesRefacto/EtapeResultat.tsx";
 import { EtapeResultatV2 } from "./EtapeResultatV2.tsx";
+import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions.ts";
 
 export function AiguilleVersEtapeResultat(props: {
   version: string;
@@ -11,14 +12,20 @@ export function AiguilleVersEtapeResultat(props: {
   const afficheLesDeux = props.version === "all";
 
   if (afficheV1) return <EtapeResultat reponses={props.reponses} />;
-  if (afficheV2) return <EtapeResultatV2 />;
+  if (afficheV2) return <EtapeResultatV2 resultat={fauxResultatReguleEE} />;
 
   if (afficheLesDeux)
     return (
       <>
         <EtapeResultat reponses={props.reponses} />
         <hr />
-        <EtapeResultatV2 />
+        <EtapeResultatV2 resultat={fauxResultatReguleEE} />
       </>
     );
 }
+
+const fauxResultatReguleEE: ResultatEligibilite = {
+  regulation: "Regule",
+  typeEntite: "EntiteEssentielle",
+  pointsAttention: { resumes: [], precisions: [] },
+};

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapeResultatV2.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapeResultatV2.tsx
@@ -1,7 +1,19 @@
-export function EtapeResultatV2() {
+import { TamponResultat } from "./Resultats/TamponResultat.tsx";
+import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions.ts";
+import { PointsAttention } from "./Resultats/PointsAttention.tsx";
+import { RowContainer } from "../General/RowContainer.tsx";
+import { CenteredContainer } from "../General/CenteredContainer.tsx";
+
+export function EtapeResultatV2(props: { resultat: ResultatEligibilite }) {
   return (
-    <div>
-      <h1>RÉSULTAT V2</h1>
-    </div>
+    <RowContainer>
+      <CenteredContainer>
+        <TamponResultat resultat={props.resultat} />
+        <PointsAttention
+          resumes={props.resultat.pointsAttention.resumes}
+          precisions={props.resultat.pointsAttention.precisions}
+        />
+      </CenteredContainer>
+    </RowContainer>
   );
 }

--- a/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/AiguilleVersEtapeResultat.stories.tsx
+++ b/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/AiguilleVersEtapeResultat.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from "@storybook/react";
+import { AiguilleVersEtapeResultat } from "../../../../Components/Simulateur/AiguilleVersEtapeResultat.tsx";
+import {
+  etatParDefaut,
+  EtatQuestionnaire,
+} from "../../../../questionnaire/reducerQuestionnaire.ts";
+
+const meta: Meta<typeof AiguilleVersEtapeResultat> = {
+  component: AiguilleVersEtapeResultat,
+  title: "Composants/Simulateur/Aiguillage vers résultat",
+};
+export default meta;
+
+const etatOseOui: EtatQuestionnaire = {
+  ...etatParDefaut,
+  designationOperateurServicesEssentiels: ["oui"],
+};
+export const Resultat = { args: { version: "v2", reponses: etatOseOui } };

--- a/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/EtapeResultatV2.stories.tsx
+++ b/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/EtapeResultatV2.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta } from "@storybook/react";
 import { EtapeResultatV2 } from "../../../../Components/Simulateur/EtapeResultatV2.tsx";
+import { ResultatEligibilite } from "../../../../../../commun/core/src/Domain/Simulateur/Regulation.definitions.ts";
 
 const meta: Meta<typeof EtapeResultatV2> = {
   component: EtapeResultatV2,
@@ -7,4 +8,13 @@ const meta: Meta<typeof EtapeResultatV2> = {
 };
 export default meta;
 
-export const Defaut = { args: {} };
+const resultat: ResultatEligibilite = {
+  regulation: "Regule",
+  typeEntite: "EntiteImportante",
+  pointsAttention: {
+    resumes: ["MecanismesExemption"],
+    precisions: ["ResilienceEntiteCritique", "SecuriteNationale", "DORA"],
+  },
+};
+
+export const Resultat = { args: { resultat } };


### PR DESCRIPTION
Cette PR permet à `<EtapeResultatV2 />` d'afficher en détail le résultat reçu en `props` :

![image](https://github.com/betagouv/anssi-nis2/assets/24898521/90b6e669-417e-4fa9-989a-a98ec243d702)

Il s'agit donc de reproduire le comportement du `<LigneResultat />` legacy, en plus simple.