### PR TITLE
Enrichissement du système de `Specifications`

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
@@ -1,47 +1,47 @@
-import { SpecificationEntiteOSE } from "./SpecificationEntiteOSE.ts";
-import { Specification, Specifications } from "./Specifications.ts";
-import { SpecificationLocalisation } from "./SpecificationLocalisation.ts";
+import { RegleEntiteOSE } from "./RegleEntiteOSE.ts";
+import { Regle, Specifications } from "./Specifications.ts";
+import { RegleLocalisation } from "./RegleLocalisation.ts";
 import { SpecificationTexte } from "./FormatDesSpecificationsCSV.ts";
 
 export class FabriqueDeSpecifications {
-  transforme(specification: SpecificationTexte): Specifications {
-    const transformations: Specification[] = [
-      this.specificationOSE(specification),
-      this.specificationLocalisation(specification),
-    ].filter((s) => s !== undefined) as Specification[];
+  transforme(texte: SpecificationTexte): Specifications {
+    const regles: Regle[] = [
+      this.regleOSE(texte),
+      this.regleLocalisation(texte),
+    ].filter((s) => s !== undefined) as Regle[];
 
-    return new Specifications(...transformations);
+    return new Specifications(...regles);
   }
 
-  private specificationOSE = (
-    specification: SpecificationTexte,
-  ): SpecificationEntiteOSE | undefined => {
-    const valeur = specification["Designation OSE"];
+  private regleOSE = (
+    texte: SpecificationTexte,
+  ): RegleEntiteOSE | undefined => {
+    const valeur = texte["Designation OSE"];
 
     if (!valeur) return;
-    if (valeur === "Oui") return new SpecificationEntiteOSE(["oui"]);
+    if (valeur === "Oui") return new RegleEntiteOSE(["oui"]);
     if (valeur === "Non / Ne sait pas")
-      return new SpecificationEntiteOSE(["non", "nsp"]);
+      return new RegleEntiteOSE(["non", "nsp"]);
 
-    throw new ErreurLectureDeSpecifications(valeur, "Designation OSE");
+    throw new ErreurLectureDeRegle(valeur, "Designation OSE");
   };
 
-  private specificationLocalisation(
-    specification: SpecificationTexte,
-  ): SpecificationLocalisation | undefined {
-    const valeur = specification["Localisation"];
+  private regleLocalisation(
+    texte: SpecificationTexte,
+  ): RegleLocalisation | undefined {
+    const valeur = texte["Localisation"];
 
     if (!valeur) return;
-    if (valeur === "France") return new SpecificationLocalisation(["france"]);
+    if (valeur === "France") return new RegleLocalisation(["france"]);
 
-    throw new ErreurLectureDeSpecifications(valeur, "Localisation");
+    throw new ErreurLectureDeRegle(valeur, "Localisation");
   }
 }
 
-class ErreurLectureDeSpecifications extends Error {
+class ErreurLectureDeRegle extends Error {
   constructor(valeurErreur: string, typeDeSpecification: string) {
     super(
-      `La valeur ${valeurErreur} est invalide pour la spécification ${typeDeSpecification}`,
+      `La valeur ${valeurErreur} est invalide pour la règle ${typeDeSpecification}`,
     );
   }
 }

--- a/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
@@ -2,6 +2,7 @@ import { RegleEntiteOSE } from "./RegleEntiteOSE.ts";
 import { Regle, Specifications } from "./Specifications.ts";
 import { RegleLocalisation } from "./RegleLocalisation.ts";
 import { SpecificationTexte } from "./FormatDesSpecificationsCSV.ts";
+import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions.ts";
 
 export class FabriqueDeSpecifications {
   transforme(texte: SpecificationTexte): Specifications {
@@ -10,7 +11,9 @@ export class FabriqueDeSpecifications {
       this.regleLocalisation(texte),
     ].filter((s) => s !== undefined) as Regle[];
 
-    return new Specifications(regles);
+    const resultat = this.transformeResultat(texte);
+
+    return new Specifications(regles, resultat);
   }
 
   private regleOSE = (
@@ -35,6 +38,54 @@ export class FabriqueDeSpecifications {
     if (valeur === "France") return new RegleLocalisation(["france"]);
 
     throw new ErreurLectureDeRegle(valeur, "Localisation");
+  }
+
+  private transformeResultat(texte: SpecificationTexte): ResultatEligibilite {
+    const valeur = texte["Resultat"];
+
+    if (valeur === "Regule EE")
+      return {
+        regulation: "Regule",
+        typeEntite: "EntiteEssentielle",
+        pointsAttention: { precisions: [], resumes: [] },
+      };
+
+    if (valeur === "Regule EI")
+      return {
+        regulation: "Regule",
+        typeEntite: "EntiteImportante",
+        pointsAttention: { precisions: [], resumes: [] },
+      };
+
+    if (valeur === "Regule enregistrement seul")
+      return {
+        regulation: "Regule",
+        typeEntite: "EnregistrementUniquement",
+        pointsAttention: { precisions: [], resumes: [] },
+      };
+
+    if (valeur === "Regule autre EM")
+      return {
+        regulation: "Regule",
+        typeEntite: "AutreEtatMembreUE",
+        pointsAttention: { precisions: [], resumes: [] },
+      };
+
+    if (valeur === "Non regule")
+      return {
+        regulation: "NonRegule",
+        typeEntite: "AutreEtatMembreUE", // Le type est sans importance ici.
+        pointsAttention: { precisions: [], resumes: [] },
+      };
+
+    if (valeur === "Incertain")
+      return {
+        regulation: "Incertain",
+        typeEntite: "AutreEtatMembreUE", // Le type est sans importance ici.
+        pointsAttention: { precisions: [], resumes: [] },
+      };
+
+    throw new ErreurLectureDeRegle(valeur, "Resultat");
   }
 }
 

--- a/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
@@ -10,7 +10,7 @@ export class FabriqueDeSpecifications {
       this.regleLocalisation(texte),
     ].filter((s) => s !== undefined) as Regle[];
 
-    return new Specifications(...regles);
+    return new Specifications(regles);
   }
 
   private regleOSE = (

--- a/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
@@ -1,6 +1,8 @@
 export enum ClesDuCSV {
   "Designation OSE",
   "Localisation",
+  "Resultat: statut",
+  "Resultat: type entite",
 }
 
 // Type créé à partir des clés du CSV.

--- a/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
@@ -1,8 +1,7 @@
 export enum ClesDuCSV {
   "Designation OSE",
   "Localisation",
-  "Resultat: statut",
-  "Resultat: type entite",
+  "Resultat",
 }
 
 // Type créé à partir des clés du CSV.

--- a/anssi-nis2-ui/src/questionnaire/specifications/LecteurDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/LecteurDeSpecifications.ts
@@ -13,13 +13,13 @@ export class LecteurDeSpecifications {
   lis(fichier: string): Specifications[] {
     const texte = fs.readFileSync(fichier).toString("utf-8");
 
-    const records = parse<SpecificationTexte>(texte, {
+    const lignes = parse<SpecificationTexte>(texte, {
       header: true,
       skipEmptyLines: true,
     });
 
-    valideColonnesDuCSV(records.meta.fields!);
+    valideColonnesDuCSV(lignes.meta.fields!);
 
-    return records.data.map((r) => this.fabrique.transforme(r));
+    return lignes.data.map((ligne) => this.fabrique.transforme(ligne));
   }
 }

--- a/anssi-nis2-ui/src/questionnaire/specifications/RegleEntiteOSE.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/RegleEntiteOSE.ts
@@ -1,9 +1,9 @@
 import { EtatQuestionnaire } from "../reducerQuestionnaire.ts";
 import { DesignationOperateurServicesEssentiels } from "../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { contientUnParmi } from "../../../../commun/utils/services/commun.predicats.ts";
-import { Specification } from "./Specifications.ts";
+import { Regle } from "./Specifications.ts";
 
-export class SpecificationEntiteOSE implements Specification {
+export class RegleEntiteOSE implements Regle {
   constructor(
     private readonly valeursAcceptees: DesignationOperateurServicesEssentiels[],
   ) {}

--- a/anssi-nis2-ui/src/questionnaire/specifications/RegleLocalisation.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/RegleLocalisation.ts
@@ -1,9 +1,9 @@
 import { EtatQuestionnaire } from "../reducerQuestionnaire.ts";
 import { AppartenancePaysUnionEuropeenne } from "../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { contientUnParmi } from "../../../../commun/utils/services/commun.predicats.ts";
-import { Specification } from "./Specifications.ts";
+import { Regle } from "./Specifications.ts";
 
-export class SpecificationLocalisation implements Specification {
+export class RegleLocalisation implements Regle {
   constructor(
     private readonly valeursAcceptees: AppartenancePaysUnionEuropeenne[],
   ) {}

--- a/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
@@ -1,17 +1,25 @@
 import { EtatQuestionnaire } from "../reducerQuestionnaire.ts";
+import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions.ts";
 
 export interface Regle {
   evalue(reponses: EtatQuestionnaire): boolean;
 }
 
 export class Specifications {
-  constructor(private readonly regles: Regle[]) {}
+  constructor(
+    private readonly regles: Regle[],
+    private readonly _resultat: ResultatEligibilite,
+  ) {}
 
   evalue(reponses: EtatQuestionnaire) {
     return this.regles.every((r) => r.evalue(reponses));
   }
 
-  public nombreDeRegles() {
+  nombreDeRegles() {
     return this.regles.length;
+  }
+
+  resultat() {
+    return this._resultat;
   }
 }

--- a/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
@@ -4,8 +4,14 @@ export interface Regle {
   evalue(reponses: EtatQuestionnaire): boolean;
 }
 
-export class Specifications extends Array<Regle> {
+export class Specifications {
+  constructor(private readonly regles: Regle[]) {}
+
   evalue(reponses: EtatQuestionnaire) {
-    return this.every((spec) => spec.evalue(reponses));
+    return this.regles.every((r) => r.evalue(reponses));
+  }
+
+  public nombreDeRegles() {
+    return this.regles.length;
   }
 }

--- a/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
@@ -11,8 +11,10 @@ export class Specifications {
     private readonly _resultat: ResultatEligibilite,
   ) {}
 
-  evalue(reponses: EtatQuestionnaire) {
-    return this.regles.every((r) => r.evalue(reponses));
+  evalue(reponses: EtatQuestionnaire): ResultatEligibilite | undefined {
+    const passeToutesLesRegles = this.regles.every((r) => r.evalue(reponses));
+
+    if (passeToutesLesRegles) return this._resultat;
   }
 
   nombreDeRegles() {

--- a/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
@@ -1,10 +1,10 @@
 import { EtatQuestionnaire } from "../reducerQuestionnaire.ts";
 
-export interface Specification {
+export interface Regle {
   evalue(reponses: EtatQuestionnaire): boolean;
 }
 
-export class Specifications extends Array<Specification> {
+export class Specifications extends Array<Regle> {
   evalue(reponses: EtatQuestionnaire) {
     return this.every((spec) => spec.evalue(reponses));
   }

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { SpecificationEntiteOSE } from "../../../src/questionnaire/specifications/SpecificationEntiteOSE";
+import { RegleEntiteOSE } from "../../../src/questionnaire/specifications/RegleEntiteOSE";
 import {
   etatParDefaut,
   EtatQuestionnaire,
@@ -33,7 +33,7 @@ describe("La fabrique de spécifications", () => {
         uneSpecification({ "Designation OSE": "Oui" }),
       );
 
-      expect(specification).toBeInstanceOf(SpecificationEntiteOSE);
+      expect(specification).toBeInstanceOf(RegleEntiteOSE);
 
       expect(specification.evalue(entiteOui)).toBe(true);
       expect(specification.evalue(entiteNon)).toBe(false);
@@ -45,7 +45,7 @@ describe("La fabrique de spécifications", () => {
         uneSpecification({ "Designation OSE": "Non / Ne sait pas" }),
       );
 
-      expect(specification).toBeInstanceOf(SpecificationEntiteOSE);
+      expect(specification).toBeInstanceOf(RegleEntiteOSE);
       expect(specification.evalue(entiteOui)).toBe(false);
       expect(specification.evalue(entiteNon)).toBe(true);
       expect(specification.evalue(entiteNeSaitPas)).toBe(true);

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { RegleEntiteOSE } from "../../../src/questionnaire/specifications/RegleEntiteOSE";
 import {
   etatParDefaut,
   EtatQuestionnaire,
@@ -14,7 +13,7 @@ describe("La fabrique de spécifications", () => {
     fabrique = new FabriqueDeSpecifications();
   });
 
-  describe("pour la spécification « d'entité OSE »", () => {
+  describe("pour la règle « d'entité OSE »", () => {
     const entiteOui: EtatQuestionnaire = {
       ...etatParDefaut,
       designationOperateurServicesEssentiels: ["oui"],
@@ -28,30 +27,29 @@ describe("La fabrique de spécifications", () => {
       designationOperateurServicesEssentiels: ["nsp"],
     };
 
-    it("sait instancier une spécification « Oui »", () => {
-      const [specification] = fabrique.transforme(
+    it("sait instancier une règle « Oui »", () => {
+      const specs = fabrique.transforme(
         uneSpecification({ "Designation OSE": "Oui" }),
       );
 
-      expect(specification).toBeInstanceOf(RegleEntiteOSE);
-
-      expect(specification.evalue(entiteOui)).toBe(true);
-      expect(specification.evalue(entiteNon)).toBe(false);
-      expect(specification.evalue(entiteNeSaitPas)).toBe(false);
+      expect(specs.nombreDeRegles()).toBe(1);
+      expect(specs.evalue(entiteOui)).toBe(true);
+      expect(specs.evalue(entiteNon)).toBe(false);
+      expect(specs.evalue(entiteNeSaitPas)).toBe(false);
     });
 
-    it("sait instancier une spécification « Non / Ne sait pas »", () => {
-      const [specification] = fabrique.transforme(
+    it("sait instancier une règle « Non / Ne sait pas »", () => {
+      const specs = fabrique.transforme(
         uneSpecification({ "Designation OSE": "Non / Ne sait pas" }),
       );
 
-      expect(specification).toBeInstanceOf(RegleEntiteOSE);
-      expect(specification.evalue(entiteOui)).toBe(false);
-      expect(specification.evalue(entiteNon)).toBe(true);
-      expect(specification.evalue(entiteNeSaitPas)).toBe(true);
+      expect(specs.nombreDeRegles()).toBe(1);
+      expect(specs.evalue(entiteOui)).toBe(false);
+      expect(specs.evalue(entiteNon)).toBe(true);
+      expect(specs.evalue(entiteNeSaitPas)).toBe(true);
     });
 
-    it("lève une exception si la spécification reçue n'est pas gérée", () => {
+    it("lève une exception si la valeur reçue n'est pas gérée", () => {
       expect(() =>
         fabrique.transforme(
           uneSpecification({ "Designation OSE": "Mauvaise valeur" }),
@@ -59,16 +57,16 @@ describe("La fabrique de spécifications", () => {
       ).toThrowError("Mauvaise valeur");
     });
 
-    it("n'instancie pas de spécification si aucune valeur n'est passée", () => {
+    it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specifications = fabrique.transforme(
         uneSpecification({ "Designation OSE": "" }),
       );
 
-      expect(specifications.length).toBe(0);
+      expect(specifications.nombreDeRegles()).toBe(0);
     });
   });
 
-  describe("pour la spécification de « Localisation »", () => {
+  describe("pour la règle de « Localisation »", () => {
     const entiteFrance: EtatQuestionnaire = {
       ...etatParDefaut,
       appartenancePaysUnionEuropeenne: ["france"],
@@ -78,30 +76,28 @@ describe("La fabrique de spécifications", () => {
       appartenancePaysUnionEuropeenne: ["autre"],
     };
 
-    it("sait instancier une spécification « France »", () => {
-      const [specification] = fabrique.transforme(
+    it("sait instancier une règle « France »", () => {
+      const specs = fabrique.transforme(
         uneSpecification({ Localisation: "France" }),
       );
 
-      const accepteFrance = specification.evalue(entiteFrance);
-      const accepteAutre = specification.evalue(entiteAutre);
-
-      expect(accepteFrance).toBe(true);
-      expect(accepteAutre).toBe(false);
+      expect(specs.nombreDeRegles()).toBe(1);
+      expect(specs.evalue(entiteFrance)).toBe(true);
+      expect(specs.evalue(entiteAutre)).toBe(false);
     });
 
-    it("lève une exception si la spécification reçue n'est pas gérée", () => {
+    it("lève une exception si la valeur reçue n'est pas gérée", () => {
       expect(() =>
         fabrique.transforme(uneSpecification({ Localisation: "12345" })),
       ).toThrowError("12345");
     });
 
-    it("n'instancie pas de spécification si aucune valeur n'est passée", () => {
+    it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specifications = fabrique.transforme(
         uneSpecification({ Localisation: "" }),
       );
 
-      expect(specifications.length).toBe(0);
+      expect(specifications.nombreDeRegles()).toBe(0);
     });
   });
 });

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -6,6 +6,7 @@ import {
 import { FabriqueDeSpecifications } from "../../../src/questionnaire/specifications/FabriqueDeSpecifications";
 import { SpecificationTexte } from "../../../src/questionnaire/specifications/FormatDesSpecificationsCSV";
 import { Specifications } from "../../../src/questionnaire/specifications/Specifications";
+import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions";
 
 describe("La fabrique de spécifications", () => {
   let fabrique: FabriqueDeSpecifications;
@@ -34,9 +35,9 @@ describe("La fabrique de spécifications", () => {
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
-      expect(specs.evalue(entiteOui)).toBe(true);
-      expect(specs.evalue(entiteNon)).toBe(false);
-      expect(specs.evalue(entiteNeSaitPas)).toBe(false);
+      expect(specs.evalue(entiteOui)).toMatchObject(reguleEE());
+      expect(specs.evalue(entiteNon)).toBe(undefined);
+      expect(specs.evalue(entiteNeSaitPas)).toBe(undefined);
     });
 
     it("sait instancier une règle « Non / Ne sait pas »", () => {
@@ -48,9 +49,9 @@ describe("La fabrique de spécifications", () => {
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
-      expect(specs.evalue(entiteOui)).toBe(false);
-      expect(specs.evalue(entiteNon)).toBe(true);
-      expect(specs.evalue(entiteNeSaitPas)).toBe(true);
+      expect(specs.evalue(entiteOui)).toBe(undefined);
+      expect(specs.evalue(entiteNon)).toMatchObject(reguleEE());
+      expect(specs.evalue(entiteNeSaitPas)).toMatchObject(reguleEE());
     });
 
     it("lève une exception si la valeur reçue n'est pas gérée", () => {
@@ -86,8 +87,8 @@ describe("La fabrique de spécifications", () => {
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
-      expect(specs.evalue(entiteFrance)).toBe(true);
-      expect(specs.evalue(entiteAutre)).toBe(false);
+      expect(specs.evalue(entiteFrance)).toMatchObject(reguleEE());
+      expect(specs.evalue(entiteAutre)).toBe(undefined);
     });
 
     it("lève une exception si la valeur reçue n'est pas gérée", () => {
@@ -176,4 +177,8 @@ function uneSpecification(
     Resultat: "CHAQUE TEST DOIT LE DÉFINIR",
     ...surcharge,
   };
+}
+
+function reguleEE(): Partial<ResultatEligibilite> {
+  return { regulation: "Regule", typeEntite: "EntiteEssentielle" };
 }

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -109,5 +109,11 @@ describe("La fabrique de spécifications", () => {
 function uneSpecification(
   surcharge: Partial<SpecificationTexte>,
 ): SpecificationTexte {
-  return { "Designation OSE": "", Localisation: "", ...surcharge };
+  return {
+    "Designation OSE": "",
+    Localisation: "",
+    "Resultat: statut": "",
+    "Resultat: type entite": "",
+    ...surcharge,
+  };
 }

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../src/questionnaire/reducerQuestionnaire";
 import { FabriqueDeSpecifications } from "../../../src/questionnaire/specifications/FabriqueDeSpecifications";
 import { SpecificationTexte } from "../../../src/questionnaire/specifications/FormatDesSpecificationsCSV";
+import { Specifications } from "../../../src/questionnaire/specifications/Specifications";
 
 describe("La fabrique de spécifications", () => {
   let fabrique: FabriqueDeSpecifications;
@@ -29,7 +30,7 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier une règle « Oui »", () => {
       const specs = fabrique.transforme(
-        uneSpecification({ "Designation OSE": "Oui" }),
+        uneSpecification({ "Designation OSE": "Oui", Resultat: "Regule EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
@@ -40,7 +41,10 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier une règle « Non / Ne sait pas »", () => {
       const specs = fabrique.transforme(
-        uneSpecification({ "Designation OSE": "Non / Ne sait pas" }),
+        uneSpecification({
+          "Designation OSE": "Non / Ne sait pas",
+          Resultat: "Regule EE",
+        }),
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
@@ -59,7 +63,7 @@ describe("La fabrique de spécifications", () => {
 
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specifications = fabrique.transforme(
-        uneSpecification({ "Designation OSE": "" }),
+        uneSpecification({ "Designation OSE": "", Resultat: "Regule EE" }),
       );
 
       expect(specifications.nombreDeRegles()).toBe(0);
@@ -78,7 +82,7 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier une règle « France »", () => {
       const specs = fabrique.transforme(
-        uneSpecification({ Localisation: "France" }),
+        uneSpecification({ Localisation: "France", Resultat: "Regule EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
@@ -94,10 +98,71 @@ describe("La fabrique de spécifications", () => {
 
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specifications = fabrique.transforme(
-        uneSpecification({ Localisation: "" }),
+        uneSpecification({ Localisation: "", Resultat: "Regule EE" }),
       );
 
       expect(specifications.nombreDeRegles()).toBe(0);
+    });
+  });
+
+  describe("pour le résultat", () => {
+    it("sait instancier un résultat « Régulée EE»", () => {
+      const specs: Specifications = fabrique.transforme(
+        uneSpecification({ Resultat: "Regule EE" }),
+      );
+
+      expect(specs.resultat().regulation).toBe("Regule");
+      expect(specs.resultat().typeEntite).toBe("EntiteEssentielle");
+    });
+
+    it("sait instancier un résultat « Régulée EI »", () => {
+      const specs: Specifications = fabrique.transforme(
+        uneSpecification({ Resultat: "Regule EI" }),
+      );
+
+      expect(specs.resultat().regulation).toBe("Regule");
+      expect(specs.resultat().typeEntite).toBe("EntiteImportante");
+    });
+
+    it("sait instancier un résultat « Régulée EI »", () => {
+      const specs: Specifications = fabrique.transforme(
+        uneSpecification({ Resultat: "Regule enregistrement seul" }),
+      );
+
+      expect(specs.resultat().regulation).toBe("Regule");
+      expect(specs.resultat().typeEntite).toBe("EnregistrementUniquement");
+    });
+
+    it("sait instancier un résultat « Régulée Autre Etat Membre »", () => {
+      const specs: Specifications = fabrique.transforme(
+        uneSpecification({ Resultat: "Regule autre EM" }),
+      );
+
+      expect(specs.resultat().regulation).toBe("Regule");
+      expect(specs.resultat().typeEntite).toBe("AutreEtatMembreUE");
+    });
+
+    it("sait instancier un résultat « Non regulée »", () => {
+      const specs: Specifications = fabrique.transforme(
+        uneSpecification({ Resultat: "Non regule" }),
+      );
+
+      expect(specs.resultat().regulation).toBe("NonRegule");
+    });
+
+    it("sait instancier un résultat « Incertain »", () => {
+      const specs: Specifications = fabrique.transforme(
+        uneSpecification({ Resultat: "Incertain" }),
+      );
+
+      expect(specs.resultat().regulation).toBe("Incertain");
+      expect(specs.resultat().typeEntite).toBe("AutreEtatMembreUE");
+    });
+
+    it("lève une exception si la valeur reçue n'est pas gérée", () => {
+      expect(() =>
+        fabrique.transforme(uneSpecification({ Resultat: "X" })),
+      ).toThrowError("X");
     });
   });
 });
@@ -108,8 +173,7 @@ function uneSpecification(
   return {
     "Designation OSE": "",
     Localisation: "",
-    "Resultat: statut": "",
-    "Resultat: type entite": "",
+    Resultat: "CHAQUE TEST DOIT LE DÉFINIR",
     ...surcharge,
   };
 }

--- a/anssi-nis2-ui/test/questionnaire/specifications/LecteurDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/LecteurDeSpecifications.spec.ts
@@ -4,11 +4,11 @@ import { LecteurDeSpecifications } from "../../../src/questionnaire/specificatio
 describe("Le lecteur de spécifications", () => {
   it("utilise un fichier CSV pour produire un tableau de toutes les spécifications", () => {
     const lecteur = new LecteurDeSpecifications();
-    const fichier = leCSV("specification-deux-lignes.csv");
+    const fichier = leCSV("specification-une-ligne.csv");
 
     const specifications = lecteur.lis(fichier);
 
-    expect(specifications.length).toBe(2);
+    expect(specifications.length).toBe(1);
   });
 
   it("lève une exception si les colonnes du CSV ne sont pas celles attendues", () => {

--- a/anssi-nis2-ui/test/questionnaire/specifications/Specifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/Specifications.spec.ts
@@ -1,36 +1,47 @@
-import { describe, expect, it } from "vitest";
-import { RegleEntiteOSE } from "../../../src/questionnaire/specifications/RegleEntiteOSE";
+import { beforeEach, describe, expect, it } from "vitest";
 import { Specifications } from "../../../src/questionnaire/specifications/Specifications";
 import {
   etatParDefaut,
   EtatQuestionnaire,
 } from "../../../src/questionnaire/reducerQuestionnaire";
+import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions";
+import { RegleEntiteOSE } from "../../../src/questionnaire/specifications/RegleEntiteOSE";
 
 describe("Les spécifications", () => {
-  const entiteOui: EtatQuestionnaire = {
-    ...etatParDefaut,
-    designationOperateurServicesEssentiels: ["oui"],
+  const resultatDeLaSpec: ResultatEligibilite = {
+    regulation: "Regule",
+    typeEntite: "EntiteEssentielle",
+    pointsAttention: { precisions: [], resumes: [] },
   };
 
-  it("acceptent un questionnaire si toutes ses réponses sont conformes aux spécifications", () => {
-    const deuxFoisOSE = new Specifications([
-      new RegleEntiteOSE(["oui"]),
-      new RegleEntiteOSE(["oui"]),
-    ]);
+  let entiteOseOuiEstReguleEE: Specifications;
 
-    const passePourOui = deuxFoisOSE.evalue(entiteOui);
-
-    expect(passePourOui).toBe(true);
+  beforeEach(() => {
+    entiteOseOuiEstReguleEE = new Specifications(
+      [new RegleEntiteOSE(["oui"])],
+      resultatDeLaSpec,
+    );
   });
 
-  it("rejettent un questionnaire si une réponse n'est pas conforme aux spécifications", () => {
-    const deuxFoisNon = new Specifications([
-      new RegleEntiteOSE(["non"]),
-      new RegleEntiteOSE(["non"]),
-    ]);
+  it("retourne le résultat spécifié si toutes les réponses du questionnaire sont conformes aux règles", () => {
+    const entiteOui: EtatQuestionnaire = {
+      ...etatParDefaut,
+      designationOperateurServicesEssentiels: ["oui"],
+    };
 
-    const passePourOui = deuxFoisNon.evalue(entiteOui);
+    const resultat = entiteOseOuiEstReguleEE.evalue(entiteOui);
 
-    expect(passePourOui).toBe(false);
+    expect(resultat).toBe(resultatDeLaSpec);
+  });
+
+  it("retourne `undefined` dès qu'une réponse du questionnaire n'est pas conforme à une règle", () => {
+    const entiteNon: EtatQuestionnaire = {
+      ...etatParDefaut,
+      designationOperateurServicesEssentiels: ["non"],
+    };
+
+    const resultat = entiteOseOuiEstReguleEE.evalue(entiteNon);
+
+    expect(resultat).toBe(undefined);
   });
 });

--- a/anssi-nis2-ui/test/questionnaire/specifications/Specifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/Specifications.spec.ts
@@ -13,10 +13,10 @@ describe("Les spécifications", () => {
   };
 
   it("acceptent un questionnaire si toutes ses réponses sont conformes aux spécifications", () => {
-    const deuxFoisOSE = new Specifications(
+    const deuxFoisOSE = new Specifications([
       new RegleEntiteOSE(["oui"]),
       new RegleEntiteOSE(["oui"]),
-    );
+    ]);
 
     const passePourOui = deuxFoisOSE.evalue(entiteOui);
 
@@ -24,10 +24,10 @@ describe("Les spécifications", () => {
   });
 
   it("rejettent un questionnaire si une réponse n'est pas conforme aux spécifications", () => {
-    const deuxFoisNon = new Specifications(
+    const deuxFoisNon = new Specifications([
       new RegleEntiteOSE(["non"]),
       new RegleEntiteOSE(["non"]),
-    );
+    ]);
 
     const passePourOui = deuxFoisNon.evalue(entiteOui);
 

--- a/anssi-nis2-ui/test/questionnaire/specifications/Specifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/Specifications.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SpecificationEntiteOSE } from "../../../src/questionnaire/specifications/SpecificationEntiteOSE";
+import { RegleEntiteOSE } from "../../../src/questionnaire/specifications/RegleEntiteOSE";
 import { Specifications } from "../../../src/questionnaire/specifications/Specifications";
 import {
   etatParDefaut,
@@ -14,8 +14,8 @@ describe("Les spécifications", () => {
 
   it("acceptent un questionnaire si toutes ses réponses sont conformes aux spécifications", () => {
     const deuxFoisOSE = new Specifications(
-      new SpecificationEntiteOSE(["oui"]),
-      new SpecificationEntiteOSE(["oui"]),
+      new RegleEntiteOSE(["oui"]),
+      new RegleEntiteOSE(["oui"]),
     );
 
     const passePourOui = deuxFoisOSE.evalue(entiteOui);
@@ -25,8 +25,8 @@ describe("Les spécifications", () => {
 
   it("rejettent un questionnaire si une réponse n'est pas conforme aux spécifications", () => {
     const deuxFoisNon = new Specifications(
-      new SpecificationEntiteOSE(["non"]),
-      new SpecificationEntiteOSE(["non"]),
+      new RegleEntiteOSE(["non"]),
+      new RegleEntiteOSE(["non"]),
     );
 
     const passePourOui = deuxFoisNon.evalue(entiteOui);

--- a/anssi-nis2-ui/test/questionnaire/specifications/specification-deux-lignes.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/specification-deux-lignes.csv
@@ -1,3 +1,3 @@
-Designation OSE,Localisation
-Oui,France
-Non / Ne sait pas,France
+Designation OSE,Localisation,Resultat: statut,Resultat: type entite
+Oui,France,,
+Non / Ne sait pas,France,,

--- a/anssi-nis2-ui/test/questionnaire/specifications/specification-une-ligne.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/specification-une-ligne.csv
@@ -1,3 +1,2 @@
 Designation OSE,Localisation,Resultat: statut,Resultat: type entite
 Oui,France,,
-Non / Ne sait pas,France,,

--- a/anssi-nis2-ui/test/questionnaire/specifications/specification-une-ligne.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/specification-une-ligne.csv
@@ -1,2 +1,2 @@
-Designation OSE,Localisation,Resultat: statut,Resultat: type entite
-Oui,France,,
+Designation OSE,Localisation,Resultat
+Oui,France,Regule EE


### PR DESCRIPTION
Avec cette PR, chaque instance de `Specifications` est désormais associée au résultat précisé sur sa ligne CSV.

Exemple : 
```csv
Designation OSE,Localisation,Resultat
Non,France,Regule EE
```

La spécification instanciée pour cette ligne renverra `Régulé EE` si les réponses sont : 
 - **Entité OSE :** Non
 - **Localisation :** France

Au passage les noms se précisent : `Specification` au singulier devient `Regle`.