### PR TITLE
Ajoute la possibilité d'opt-out du suivi Matomo

### DIFF
--- a/anssi-nis2-ui/src/Components/Matomo/Matomo.tsx
+++ b/anssi-nis2-ui/src/Components/Matomo/Matomo.tsx
@@ -1,11 +1,16 @@
 import { Helmet } from "react-helmet";
 import { DefaultComponentExtensible, MatomoProps } from "../../Services/Props";
+import { useConfigurationMatomo } from "./useConfigurationMatomo.hook.tsx";
+import { Fragment } from "react";
 
 const Matomo: DefaultComponentExtensible<MatomoProps> = ({
   SiteId,
   JavascriptContainerHash,
   GestionBalises,
 }: MatomoProps) => {
+  const [optOut] = useConfigurationMatomo();
+  if (optOut) return <Fragment />;
+
   const scriptMatomoJavascript = `var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(['trackPageView']);
@@ -23,6 +28,7 @@ const Matomo: DefaultComponentExtensible<MatomoProps> = ({
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.async=true; g.src='https://stats.beta.gouv.fr/js/container_${JavascriptContainerHash}.js'; s.parentNode.insertBefore(g,s);
   })();`;
+
   return (
     <>
       <Helmet>

--- a/anssi-nis2-ui/src/Components/Matomo/Matomo.tsx
+++ b/anssi-nis2-ui/src/Components/Matomo/Matomo.tsx
@@ -1,5 +1,5 @@
 import { Helmet } from "react-helmet";
-import { DefaultComponentExtensible, MatomoProps } from "../Services/Props";
+import { DefaultComponentExtensible, MatomoProps } from "../../Services/Props";
 
 const Matomo: DefaultComponentExtensible<MatomoProps> = ({
   SiteId,

--- a/anssi-nis2-ui/src/Components/Matomo/MatomoOptOut.tsx
+++ b/anssi-nis2-ui/src/Components/Matomo/MatomoOptOut.tsx
@@ -1,0 +1,23 @@
+import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
+import { useConfigurationMatomo } from "./useConfigurationMatomo.hook.tsx";
+
+export function MatomoOptOut() {
+  const [optOut, setOptOut] = useConfigurationMatomo();
+
+  return (
+    <Checkbox
+      legend="Toutefois, vous pouvez, à tout moment, refuser d'être suivi de manière anonyme en décochant la case ci-dessous :"
+      options={[
+        {
+          label: optOut
+            ? "Vous n'êtes actuellement pas suivi(e). Cochez cette case pour réactiver le suivi."
+            : "Vous êtes suivi(e) de manière anonyme. Décochez cette case pour vous exclure du suivi.",
+          nativeInputProps: {
+            checked: !optOut,
+            onChange: () => setOptOut(!optOut),
+          },
+        },
+      ]}
+    />
+  );
+}

--- a/anssi-nis2-ui/src/Components/Matomo/useConfigurationMatomo.hook.tsx
+++ b/anssi-nis2-ui/src/Components/Matomo/useConfigurationMatomo.hook.tsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+export const useConfigurationMatomo = (): [
+  boolean,
+  (estOptOut: boolean) => void,
+] => {
+  const [optOut, setOptOutState] = useState<boolean>(
+    localStorage.getItem("optOutMatomo") === "true",
+  );
+
+  const setOptOut = (estOptOut: boolean) => {
+    setOptOutState(estOptOut);
+    localStorage.setItem("optOutMatomo", String(estOptOut));
+    window.location.reload();
+  };
+
+  return [optOut, setOptOut];
+};

--- a/anssi-nis2-ui/src/Components/MiseEnPage.tsx
+++ b/anssi-nis2-ui/src/Components/MiseEnPage.tsx
@@ -2,7 +2,7 @@ import { DefaultComponent, DefaultProps } from "../Services/Props";
 import EnTete from "./EnTete.tsx";
 import PiedDePage from "./PiedDePage.tsx";
 import "../App.scss";
-import Matomo from "./Matomo.tsx";
+import Matomo from "./Matomo/Matomo.tsx";
 import { Helmet } from "react-helmet";
 import { BOM } from "./BOM/BOM.tsx";
 

--- a/anssi-nis2-ui/src/Components/PagesEdito/GestionCookies.tsx
+++ b/anssi-nis2-ui/src/Components/PagesEdito/GestionCookies.tsx
@@ -1,4 +1,5 @@
 import { DefaultComponent } from "../../Services/Props";
+import { MatomoOptOut } from "../Matomo/MatomoOptOut";
 
 const GestionCookies: DefaultComponent = () => {
   return (
@@ -36,6 +37,7 @@ const GestionCookies: DefaultComponent = () => {
         anonymisée avant d’être enregistrée. Il est donc impossible d’associer
         vos visites sur ce site à votre personne.
       </p>
+      <MatomoOptOut />
       <h3>Je contribue à enrichir vos données, puis-je y accéder&nbsp;?</h3>
       <p>
         Bien sûr ! Les statistiques d’usage de la majorité de nos produits, dont

--- a/anssi-nis2-ui/src/stories/Components/Transverses/GestionCoookies.stories.tsx
+++ b/anssi-nis2-ui/src/stories/Components/Transverses/GestionCoookies.stories.tsx
@@ -1,0 +1,12 @@
+import { Meta } from "@storybook/react";
+import GestionCookies from "../../../Components/PagesEdito/GestionCookies.tsx";
+
+const Index: Meta<typeof GestionCookies> = {
+  title: "Composants/Transverses/Gestion des cookies",
+  component: GestionCookies,
+  parameters: {},
+};
+
+export default Index;
+
+export { Index };


### PR DESCRIPTION
Cette PR ajoute une checkbox sur la page `/gestion-des-cookies`. 
Cette checkbox permet à l'utilisateur de désactiver le suivi Matomo.