### PR TITLE
[Éligibilité en CSV] Nouvelle règle « Secteurs »

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
@@ -6,6 +6,7 @@ import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulate
 import { RegleTypeDeStructure } from "./regles/RegleTypeDeStructure.ts";
 import { RegleTaille } from "./regles/RegleTaille.ts";
 import { ErreurLectureDeRegle } from "./regles/ErreurLectureDeRegle.ts";
+import { RegleSecteurs } from "./regles/RegleSecteurs.ts";
 
 export class FabriqueDeSpecifications {
   transforme(texte: SpecificationTexte): Specifications {
@@ -14,6 +15,7 @@ export class FabriqueDeSpecifications {
       RegleLocalisation.nouvelle(texte),
       RegleTypeDeStructure.nouvelle(texte),
       RegleTaille.nouvelle(texte),
+      RegleSecteurs.nouvelle(texte),
     ].filter((s) => s !== undefined) as Regle[];
 
     const resultat = this.transformeResultat(texte);

--- a/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
@@ -3,6 +3,7 @@ export enum ClesDuCSV {
   "Localisation",
   "Type de structure",
   "Taille",
+  "Secteurs",
   "Resultat",
 }
 

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleSecteurs.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleSecteurs.ts
@@ -1,0 +1,31 @@
+import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
+import { Regle } from "../Specifications.ts";
+import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
+import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
+import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
+import { libellesSecteursActivite } from "../../../References/LibellesSecteursActivite.ts";
+import { SecteurActivite } from "../../../../../commun/core/src/Domain/Simulateur/SecteurActivite.definitions.ts";
+
+export class RegleSecteurs implements Regle {
+  constructor(private readonly secteurActivite: SecteurActivite) {}
+
+  evalue(reponses: EtatQuestionnaire): boolean {
+    const secteurs = reponses.secteurActivite;
+    return contientUnParmi(this.secteurActivite)(secteurs);
+  }
+
+  static nouvelle(texte: SpecificationTexte): RegleSecteurs | undefined {
+    const secteurAttendu = texte["Secteurs"];
+
+    if (!secteurAttendu) return;
+
+    const secteur = Object.entries(libellesSecteursActivite).find(
+      ([, valeur]) => valeur == secteurAttendu,
+    );
+
+    if (!secteur) throw new ErreurLectureDeRegle(secteurAttendu, "Secteurs");
+
+    const [id] = secteur;
+    return new RegleSecteurs(id as SecteurActivite);
+  }
+}

--- a/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
+++ b/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
@@ -1,2 +1,2 @@
-Designation OSE,Localisation,Type de structure,Taille,Resultat
-Oui,,,,Regule EE
+Designation OSE,Localisation,Type de structure,Taille,Secteurs,Resultat
+Oui,,,,,Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
@@ -1,2 +1,2 @@
-Designation OSE,Localisation,Type de structure,Taille,Resultat
-Oui,,,,Regule EE
+Designation OSE,Localisation,Type de structure,Taille,Secteurs,Resultat
+Oui,,,,,Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
@@ -1,2 +1,2 @@
-Designation OSE,Localisation,Type de structure,Taille,Resultat
-Oui,France,,,Regule EE
+Designation OSE,Localisation,Type de structure,Taille,Secteurs,Resultat
+Oui,France,,,,Regule EE


### PR DESCRIPTION
Cette PR continue sur la trajectoire de « spécification en CSV ».

Cette fois on ajoute la règle sur les Secteurs. Les secteurs reconnus sont ceux qui sont montrés à l'écran.
