### PR TITLE
Spécifie explicitement le séparateur du CSV

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/LecteurDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/LecteurDeSpecifications.ts
@@ -13,6 +13,7 @@ export class LecteurDeSpecifications {
     const lignes = parse<SpecificationTexte>(contenuCsv, {
       header: true,
       skipEmptyLines: true,
+      delimiter: ";",
     });
 
     valideColonnesDuCSV(lignes.meta.fields!);

--- a/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
+++ b/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
@@ -1,2 +1,2 @@
-Designation OSE,Localisation,Type de structure,Taille,Secteurs,Resultat
-Oui,,,,,Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Resultat
+Oui;;;;;Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
@@ -1,2 +1,2 @@
-Designation OSE,Localisation,Type de structure,Taille,Secteurs,Resultat
-Oui,,,,,Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Resultat
+Oui;;;;;Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
@@ -1,2 +1,2 @@
-Designation OSE,Localisation,Type de structure,Taille,Secteurs,Resultat
-Oui,France,,,,Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Resultat
+Oui;France;;;;Regule EE


### PR DESCRIPTION
On utilise « ; » qui est le standard en France.