### PR TITLE
[Éligibilité en CSV] Nouvelle règle « Sous-secteurs »

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
@@ -7,6 +7,7 @@ import { RegleTypeDeStructure } from "./regles/RegleTypeDeStructure.ts";
 import { RegleTaille } from "./regles/RegleTaille.ts";
 import { ErreurLectureDeRegle } from "./regles/ErreurLectureDeRegle.ts";
 import { RegleSecteurs } from "./regles/RegleSecteurs.ts";
+import { RegleSousSecteurs } from "./regles/RegleSousSecteurs.ts";
 
 export class FabriqueDeSpecifications {
   transforme(texte: SpecificationTexte): Specifications {
@@ -16,6 +17,7 @@ export class FabriqueDeSpecifications {
       RegleTypeDeStructure.nouvelle(texte),
       RegleTaille.nouvelle(texte),
       RegleSecteurs.nouvelle(texte),
+      RegleSousSecteurs.nouvelle(texte),
     ].filter((s) => s !== undefined) as Regle[];
 
     const resultat = this.transformeResultat(texte);

--- a/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
@@ -4,6 +4,7 @@ export enum ClesDuCSV {
   "Type de structure",
   "Taille",
   "Secteurs",
+  "Sous-secteurs",
   "Resultat",
 }
 

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleSousSecteurs.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleSousSecteurs.ts
@@ -1,0 +1,54 @@
+import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
+import { Regle } from "../Specifications.ts";
+import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
+import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
+import { libellesSousSecteursActivite } from "../../../References/LibellesSousSecteursActivite.ts";
+import { SousSecteurActivite } from "../../../../../commun/core/src/Domain/Simulateur/SousSecteurActivite.definitions.ts";
+import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
+
+export class RegleSousSecteurs implements Regle {
+  constructor(private readonly sousSecteurAttendu: SousSecteurActivite) {}
+
+  evalue(reponses: EtatQuestionnaire): boolean {
+    const sousSecteurs = reponses.sousSecteurActivite;
+    return contientUnParmi(this.sousSecteurAttendu)(sousSecteurs);
+  }
+
+  static nouvelle(texte: SpecificationTexte): RegleSousSecteurs | undefined {
+    const sousSecteurAttendu = texte["Sous-secteurs"];
+
+    if (!sousSecteurAttendu) return;
+
+    return sousSecteurAttendu === "Autre sous-secteur"
+      ? chercheSousSecteurAutre(texte["Secteurs"])
+      : chercheSousSecteurPrecis(sousSecteurAttendu);
+  }
+}
+
+const chercheSousSecteurAutre = (secteurParent: string) => {
+  switch (secteurParent) {
+    case "Énergie":
+      return new RegleSousSecteurs("autreSousSecteurEnergie");
+    case "Fabrication":
+      return new RegleSousSecteurs("autreSousSecteurFabrication");
+    case "Transports":
+      return new RegleSousSecteurs("autreSousSecteurTransports");
+    default:
+      throw new ErreurLectureDeRegle(
+        `Autre sous-secteur pour le secteur parent ${secteurParent}`,
+        "Sous-secteur",
+      );
+  }
+};
+
+const chercheSousSecteurPrecis = (sousSecteurAttendu: string) => {
+  const sousSecteurCorrespondant = Object.entries(
+    libellesSousSecteursActivite,
+  ).find(([, valeur]) => valeur == sousSecteurAttendu);
+
+  if (!sousSecteurCorrespondant)
+    throw new ErreurLectureDeRegle(sousSecteurAttendu, "Sous-secteurs");
+
+  const [id] = sousSecteurCorrespondant;
+  return new RegleSousSecteurs(id as SousSecteurActivite);
+};

--- a/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
+++ b/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Resultat
-Oui;;;;;Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Resultat
+Oui;;;;;;Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Resultat
-Oui;;;;;Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Resultat
+Oui;;;;;;Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Resultat
-Oui;France;;;;Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Resultat
+Oui;France;;;;;Regule EE


### PR DESCRIPTION
Cette PR continue sur la trajectoire de « spécification en CSV ».

Cette fois on ajoute la règle sur les Sous-secteurs. Les sous-secteurs reconnus sont ceux qui sont montrés à l'écran.