### PR TITLE
[Éligibilité en CSV] Début de la nouvelle règle « Activités »

### DIFF
--- a/anssi-nis2-ui/src/References/LibellesActivites.ts
+++ b/anssi-nis2-ui/src/References/LibellesActivites.ts
@@ -220,8 +220,7 @@ export const libellesActivites: Record<Activite, string> = {
   fournisseurServiceCommunicationElectroniquesPublics:
     "Fournisseurs de services de communications électroniques accessibles au public",
   fournisseurServicesDNS:
-    "Fournisseurs de services DNS, à l'exclusion des opérateurs de serveurs " +
-    "racines de noms de domaines",
+    "Fournisseurs de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines",
   fournisseurServicesGeres: "Fournisseurs de services gérés",
   fournisseurServicesInformatiqueNuage:
     "Fournisseurs de services d'informatique en nuage",

--- a/anssi-nis2-ui/src/References/LibellesActivites.ts
+++ b/anssi-nis2-ui/src/References/LibellesActivites.ts
@@ -2,18 +2,18 @@ import { Activite } from "anssi-nis2-core/src/Domain/Simulateur/Activite.definit
 
 export const libellesActivites: Record<Activite, string> = {
   acteurDuMarche:
-    "Acteurs du marché fournissant des services d’agrégation, de " +
-    "participation active de la demande ou de stockage d’énergie",
+    "Acteurs du marché fournissant des services d'agrégation, de " +
+    "participation active de la demande ou de stockage d'énergie",
   administrationPouvoirsPublicsCentraux:
-    "Entités de l’administration publique des pouvoirs publics centraux " +
+    "Entités de l'administration publique des pouvoirs publics centraux " +
     "définies comme telles par un État membre conformément au droit national",
   administrationPubliqueNiveauRegional:
-    "Entités de l’administration publique au niveau régional définies comme " +
+    "Entités de l'administration publique au niveau régional définies comme " +
     "telles par un État membre conformément au droit national",
   autoritesRoutieresControleGestionCirculation:
     "Autorités routières chargées du contrôle de la gestion de la " +
-    "circulation, à l’exclusion des entités publiques pour lesquelles la " +
-    "gestion de la circulation ou l’exploitation de systèmes de transport " +
+    "circulation, à l'exclusion des entités publiques pour lesquelles la " +
+    "gestion de la circulation ou l'exploitation de systèmes de transport " +
     "intelligents constituent une partie non essentielle de leur activité " +
     "générale",
   autreActiviteAdministrationPublique: "Autre activité",
@@ -51,7 +51,7 @@ export const libellesActivites: Record<Activite, string> = {
   collectantEvacuantTraitantEaux:
     "Entreprises collectant, évacuant ou traitant les eaux urbaines " +
     "résiduaires, les eaux ménagères usées ou les eaux industrielles usées, " +
-    "à l’exclusion des entreprises pour lesquelles la collecte, l’évacuation " +
+    "à l'exclusion des entreprises pour lesquelles la collecte, l'évacuation " +
     "ou le traitement des eaux urbaines résiduaires, des eaux ménagères " +
     "usées ou des eaux industrielles usées constituent une partie non " +
     "essentielle de leur activité générale",
@@ -63,7 +63,7 @@ export const libellesActivites: Record<Activite, string> = {
     "Construction de bateaux et navires militaires",
   constructionBateauxPlaisance: "Construction de bateaux de plaisance",
   constructionLocomotivesAutreMaterielFerroviaireRoulant:
-    "Construction de locomotives et d’autre matériel ferroviaire roulant",
+    "Construction de locomotives et d'autre matériel ferroviaire roulant",
   constructionNavale: "Construction navale",
   constructionNaviresStructuresFlottantesCiviles:
     "Construction de navires et de structures flottantes civiles",
@@ -73,82 +73,82 @@ export const libellesActivites: Record<Activite, string> = {
   contrepartieCentrales: "Contreparties centrales",
   entiteCentralesStockage: "Entités centrales de stockage",
   entiteGestionnaireAeroports:
-    "Entités gestionnaires d’aéroports, aéroports, " +
+    "Entités gestionnaires d'aéroports, aéroports, " +
     "y compris les aéroports du réseau central, et entités exploitant les " +
     "installations annexes se trouvant dans les aéroports",
   entiteGestionnairePorts:
     "Entités gestionnaires des ports, y compris les " +
     "installations portuaires, ainsi que les entités exploitant des " +
-    "infrastructures et des équipements à l’intérieur des ports",
+    "infrastructures et des équipements à l'intérieur des ports",
   entrepriseElectriciteRemplissantFonctionFourniture:
-    "Entreprise d’électricité remplissant une fonction de fourniture",
+    "Entreprise d'électricité remplissant une fonction de fourniture",
   entrepriseFerroviaire:
-    "Entreprises ferroviaires, y compris les exploitants d’installation de " +
+    "Entreprises ferroviaires, y compris les exploitants d'installation de " +
     "service",
   entrepriseFourniture: "Entreprises de fourniture",
   etablissementCredit: "Établissements de crédit",
   executantOperationGestionDechets:
     "Entreprises exécutant des opérations de gestion des déchets, à " +
-    "l’exclusion des entreprises pour lesquelles la gestion des déchets " +
-    "n’est pas la principale activité économique",
+    "l'exclusion des entreprises pour lesquelles la gestion des déchets " +
+    "n'est pas la principale activité économique",
   exploitantsInfrastructureTerrestresFournitureServicesSpaciaux:
-    "Exploitants d’infrastructures terrestres, détenues, gérées et " +
+    "Exploitants d'infrastructures terrestres, détenues, gérées et " +
     "exploitées par des États membres ou par des parties privées, qui " +
-    "soutiennent la fourniture de services spatiaux, à l’exclusion des " +
+    "soutiennent la fourniture de services spatiaux, à l'exclusion des " +
     "fournisseurs de réseaux de communications électroniques publics",
   exploitantsInstallationPetrole:
-    "Exploitants d’installations de production, de raffinage, de traitement, " +
+    "Exploitants d'installations de production, de raffinage, de traitement, " +
     "de stockage et de transport de pétrole",
-  exploitantsOleoduc: "Exploitants d’oléoducs",
+  exploitantsOleoduc: "Exploitants d'oléoducs",
   exploitantsPlateformesNegociation:
     "Exploitants de plates-formes de négociation",
   exploitantsPointRecharge:
-    "Exploitants d’un point de recharge qui sont responsables de la gestion " +
-    "et de l’exploitation d’un point de recharge, lequel fournit un service " +
+    "Exploitants d'un point de recharge qui sont responsables de la gestion " +
+    "et de l'exploitation d'un point de recharge, lequel fournit un service " +
     "de recharge aux utilisateurs finals, y compris au nom et pour le compte " +
-    "d’un prestataire de services de mobilité",
+    "d'un prestataire de services de mobilité",
   exploitantsServiceTrafficMaritime:
     "Exploitants de services de trafic maritime (STM)",
   exploitantsSystemeHydrogene:
     "Exploitants de systèmes de production, de stockage et de transport " +
-    "d’hydrogène",
+    "d'hydrogène",
   exploitantsSystemeTransportIntelligents:
     "Exploitants de systèmes de transport intelligents",
   fabricationDistributionSubstances:
     "Entreprises procédant à la fabrication de substances et à la " +
     "distribution de substances ou de mélanges et entreprises procédant " +
-    "à la production d’articles, à partir de substances ou de mélanges",
+    "à la production d'articles, à partir de substances ou de mélanges",
   fabricationMaterielTransportNCA:
     "Fabrication de matériels de transport n.c.a.\n" +
     "- Fabrication de motocycles\n" +
     "- Fabrication de bicyclettes et de véhicules pour invalides\n" +
-    "- Fabrication d’autres équipements de transport n.c.a.",
-  fabriquantAppareilEclairage: "Fabrication d’appareils d’éclairage",
+    "- Fabrication d'autres équipements de transport n.c.a.",
+  fabriquantAppareilEclairage: "Fabrication d'appareils d'éclairage",
   fabriquantAppareilsMenagers:
-    "Fabrication d’appareils ménagers\n" +
-    "- Fabrication d’appareils électroménagers\n" +
-    "- Fabrication d’appareils ménagers non électriques",
+    "Fabrication d'appareils ménagers\n" +
+    "- Fabrication d'appareils électroménagers\n" +
+    "- Fabrication d'appareils ménagers non électriques",
   fabriquantAutresMachinesUsageGeneral:
-    "Fabrication d’autres machines d’usage général\n" +
-    "- Fabrication de fours et brûleurs et d’équipements fixes de chauffage " +
+    "Fabrication d'autres machines d'usage général\n" +
+    "- Fabrication de fours et brûleurs et d'équipements fixes de chauffage " +
     "domestique\n" +
     "- Fabrication de matériel de levage et de manutention\n" +
-    "- Fabrication de machines et d’équipements de bureau (à l’exception " +
+    "- Fabrication de machines et d'équipements de bureau (à l'exception " +
     "des ordinateurs et équipements périphériques)\n" +
-    "- Fabrication d’outillage portatif à moteur incorporé\n" +
-    "- Fabrication d’équipements aérauliques et frigorifiques industriels\n" +
-    "- Fabrication de machines diverses d’usage général\n",
+    "- Fabrication d'outillage portatif à moteur incorporé\n" +
+    "- Fabrication d'équipements aérauliques et frigorifiques industriels\n" +
+    "- Fabrication de machines diverses d'usage général\n",
   fabriquantAutresMachinesUsageSpecifiqueNCA:
-    "Fabrication d’autres machines d’usage spécifique\n" +
+    "Fabrication d'autres machines d'usage spécifique\n" +
     "- Fabrication de machines pour la métallurgie\n" +
-    "- Fabrication de machines pour l’extraction ou la construction\n" +
-    "- Fabrication de machines pour l’industrie agroalimentaire\n" +
+    "- Fabrication de machines pour l'extraction ou la construction\n" +
+    "- Fabrication de machines pour l'industrie agroalimentaire\n" +
     "- Fabrication de machines pour les industries textiles et du cuir\n" +
     "- Fabrication de machines pour les industries du papier et du carton\n" +
     "- Fabrication de machines pour le travail du caoutchouc ou des " +
     "plastiques\n" +
     "- Fabrication de machines de fabrication additive\n" +
-    "- Fabrication d’autres machines d’usage spécifique n.c.a.",
+    "- Fabrication d'autres machines d'usage spécifique n.c.a.",
   fabriquantCarrosseriesVehiculesAutomobiles:
     "Fabrication de carrosseries de véhicules automobiles; fabrication de " +
     "remorques et de semi-remorques",
@@ -158,37 +158,37 @@ export const libellesActivites: Record<Activite, string> = {
     "- Fabrication de cartes électroniques assemblées",
   fabriquantDispositifsMedicaux:
     "Entités fabriquant des dispositifs médicaux et entités fabriquant des " +
-    "dispositifs médicaux de diagnostic in vitro, à l’exception des entités " +
-    "fabriquant des dispositifs médicaux mentionnés à l’annexe I, point 5, " +
+    "dispositifs médicaux de diagnostic in vitro, à l'exception des entités " +
+    "fabriquant des dispositifs médicaux mentionnés à l'annexe I, point 5, " +
     "cinquième tiret, de la présente directive",
   fabriquantDispositifsMedicauxCritiques:
     "Entités fabriquant des dispositifs médicaux considérés comme critiques " +
-    "en cas d’urgence de santé publique",
+    "en cas d'urgence de santé publique",
   fabriquantEquipementCommunication:
-    "Fabrication d’équipements de communication",
+    "Fabrication d'équipements de communication",
   fabriquantEquipementIrradiationMedicaleElectromedicauxElectrotherapeutiques:
-    "Fabrication d’équipements d’irradiation médicale, d’équipements " +
+    "Fabrication d'équipements d'irradiation médicale, d'équipements " +
     "électromédicaux et électrothérapeutiques",
   fabriquantEquipementsAutomobiles:
-    "Fabrication d’équipements automobiles\n" +
-    "- Fabrication d’équipements électriques et électroniques automobiles\n" +
-    "- Fabrication d’autres équipements automobiles",
+    "Fabrication d'équipements automobiles\n" +
+    "- Fabrication d'équipements électriques et électroniques automobiles\n" +
+    "- Fabrication d'autres équipements automobiles",
   fabriquantFilsCablesMaterielInstallationElectrique:
-    "Fabrication de fils et câbles et de matériel d’installation électrique\n" +
+    "Fabrication de fils et câbles et de matériel d'installation électrique\n" +
     "- Fabrication de câbles de fibres optiques\n" +
-    "- Fabrication d’autres fils et câbles électroniques ou électriques\n" +
-    "- Fabrication de matériel d’installation électrique",
+    "- Fabrication d'autres fils et câbles électroniques ou électriques\n" +
+    "- Fabrication de matériel d'installation électrique",
   fabriquantInstrumentsMesureEssaiNavigationHorlogerie:
-    "Fabrication d’instruments de mesure, d’essai et de navigation ; horlogerie",
+    "Fabrication d'instruments de mesure, d'essai et de navigation ; horlogerie",
   fabriquantMachineEquipementNCA:
     "Fabrication de machines et équipements n.c.a.",
   fabriquantMachineUsageGeneral:
-    "Fabrication de machines d’usage général\n" +
-    "Fabrication de moteurs et turbines, à l’exception des moteurs d’avions et de véhicules\n" +
-    "Fabrication d’équipements hydrauliques et pneumatiques\n" +
-    "Fabrication d’autres pompes et compresseurs\n" +
-    "Fabrication d’autres articles de robinetterie\n" +
-    "Fabrication d’engrenages et d’organes mécaniques de transmission",
+    "Fabrication de machines d'usage général\n" +
+    "Fabrication de moteurs et turbines, à l'exception des moteurs d'avions et de véhicules\n" +
+    "Fabrication d'équipements hydrauliques et pneumatiques\n" +
+    "Fabrication d'autres pompes et compresseurs\n" +
+    "Fabrication d'autres articles de robinetterie\n" +
+    "Fabrication d'engrenages et d'organes mécaniques de transmission",
   fabriquantMachinesAgricolesForestieres:
     "Fabrication de machines agricoles et forestières",
   fabriquantMachinesFormageMetauxMachinesOutils:
@@ -200,9 +200,9 @@ export const libellesActivites: Record<Activite, string> = {
     "Fabrication de moteurs, génératrices et transformateurs électriques et " +
     "de matériel de distribution et de commande électrique",
   fabriquantOrdinateursEquipementsPeripheriques:
-    "Fabrication d’ordinateurs et d’équipements périphériques",
+    "Fabrication d'ordinateurs et d'équipements périphériques",
   fabriquantPilesAccumulateursElectriques:
-    "Fabrication de piles et d’accumulateurs électriques",
+    "Fabrication de piles et d'accumulateurs électriques",
   fabriquantProduitPreparationsPharmaceutiques:
     "Entités fabriquant des produits pharmaceutiques de base et des " +
     "préparations pharmaceutiques",
@@ -210,7 +210,7 @@ export const libellesActivites: Record<Activite, string> = {
     "Fabrication de produits électroniques grand public",
   fabriquantProduitsInformatiquesElectroniquesOptiques:
     "Fabrication de produits informatiques, électroniques et optiques",
-  fournisseurPointEchangeInternet: "Fournisseurs de points d’échange internet",
+  fournisseurPointEchangeInternet: "Fournisseurs de points d'échange internet",
   fournisseurReseauxCommunicationElectroniquesPublics:
     "Fournisseurs de réseaux de communications électroniques publics",
   fournisseurReseauxDiffusionContenu:
@@ -220,18 +220,18 @@ export const libellesActivites: Record<Activite, string> = {
   fournisseurServiceCommunicationElectroniquesPublics:
     "Fournisseurs de services de communications électroniques accessibles au public",
   fournisseurServicesDNS:
-    "Fournisseurs de services DNS, à l’exclusion des opérateurs de serveurs " +
+    "Fournisseurs de services DNS, à l'exclusion des opérateurs de serveurs " +
     "racines de noms de domaines",
   fournisseurServicesGeres: "Fournisseurs de services gérés",
   fournisseurServicesInformatiqueNuage:
-    "Fournisseurs de services d’informatique en nuage",
+    "Fournisseurs de services d'informatique en nuage",
   fournisseurServicesSecuriteGeres:
     "Fournisseurs de services de sécurité gérés",
   fournisseursDistributeursEauxConsommation:
-    "Fournisseurs et distributeurs d’eaux destinées à la consommation " +
-    "humaine, à l’exclusion des distributeurs pour lesquels la distribution " +
-    "d’eaux destinées à la consommation humaine constitue une partie non " +
-    "essentielle de leur activité générale de distribution d’autres produits " +
+    "Fournisseurs et distributeurs d'eaux destinées à la consommation " +
+    "humaine, à l'exclusion des distributeurs pour lesquels la distribution " +
+    "d'eaux destinées à la consommation humaine constitue une partie non " +
+    "essentielle de leur activité générale de distribution d'autres produits " +
     "et biens",
   fournisseursMoteursRechercheEnLigne:
     "Fournisseurs de moteurs de recherche en ligne",
@@ -239,15 +239,15 @@ export const libellesActivites: Record<Activite, string> = {
   fournisseursPlateformesServicesReseauxSociaux:
     "Fournisseurs de plateformes de services de réseaux sociaux",
   fournisseurServicesEnregristrementNomDomaine:
-    "Fournisseur des services d’enregistrement de noms de domaine",
+    "Fournisseur des services d'enregistrement de noms de domaine",
   gestionnaireInfrastructure: "Gestionnaires des infrastructures",
-  gestionnaireInstallationGNL: "Gestionnaires d’installation de GNL",
-  gestionnaireInstallationStockage: "Gestionnaires d’installation de stockage",
+  gestionnaireInstallationGNL: "Gestionnaires d'installation de GNL",
+  gestionnaireInstallationStockage: "Gestionnaires d'installation de stockage",
   gestionnaireReseau: "Gestionnaire de réseau de distribution",
   gestionnaireReseauDistribution: "Gestionnaires de réseau de distribution",
   gestionnaireReseauTransportGaz: "Gestionnaire de réseau de transport",
   gestionnaireReseauTransportElectricite: "Gestionnaire de réseau de transport",
-  laboratoireReferenceUE: "Laboratoires de référence de l’Union européenne",
+  laboratoireReferenceUE: "Laboratoires de référence de l'Union européenne",
   operateurDesigneMarcheOuNemo: "Opérateur désigné du marché ou NEMO",
   operateurReseauChaleurFroid:
     "Opérateurs de réseaux de chaleur ou de réseaux de froid",
@@ -259,7 +259,7 @@ export const libellesActivites: Record<Activite, string> = {
   prestataireSoinsSante: "Prestataires de soins de santé",
   prestatairesServicesPostauxExpedition:
     "Prestataires de services postaux, y compris les prestataires de " +
-    "services d’expédition",
+    "services d'expédition",
   producteur: "Producteurs",
   rechercheDeveloppementMedicament:
     "Entités exerçant des activités de recherche et de développement dans le " +
@@ -273,8 +273,8 @@ export const libellesActivites: Record<Activite, string> = {
   serviceControleCirculationAerienne:
     "Services du contrôle de la circulation aérienne",
   societeTransportEaux:
-    "Sociétés de transport par voie d’eau intérieure, maritime et côtier de " +
-    "passagers et de fret, à l’exclusion des navires exploités à titre " +
+    "Sociétés de transport par voie d'eau intérieure, maritime et côtier de " +
+    "passagers et de fret, à l'exclusion des navires exploités à titre " +
     "individuel par ces sociétés",
   transporteursAeriensCommercial:
     "Transporteurs aériens à des fins commerciales",

--- a/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
@@ -8,6 +8,7 @@ import { RegleTaille } from "./regles/RegleTaille.ts";
 import { ErreurLectureDeRegle } from "./regles/ErreurLectureDeRegle.ts";
 import { RegleSecteurs } from "./regles/RegleSecteurs.ts";
 import { RegleSousSecteurs } from "./regles/RegleSousSecteurs.ts";
+import { RegleActivites } from "./regles/RegleActivites.ts";
 
 export class FabriqueDeSpecifications {
   transforme(texte: SpecificationTexte): Specifications {
@@ -18,6 +19,7 @@ export class FabriqueDeSpecifications {
       RegleTaille.nouvelle(texte),
       RegleSecteurs.nouvelle(texte),
       RegleSousSecteurs.nouvelle(texte),
+      RegleActivites.nouvelle(texte),
     ].filter((s) => s !== undefined) as Regle[];
 
     const resultat = this.transformeResultat(texte);

--- a/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
@@ -5,6 +5,7 @@ export enum ClesDuCSV {
   "Taille",
   "Secteurs",
   "Sous-secteurs",
+  "Activités",
   "Resultat",
 }
 

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
@@ -4,6 +4,7 @@ import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
 import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
 import { Activite } from "../../../../../commun/core/src/Domain/Simulateur/Activite.definitions.ts";
 import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
+import { libellesActivites } from "../../../References/LibellesActivites.ts";
 
 export class RegleActivites implements Regle {
   constructor(private readonly activite: Activite) {}
@@ -18,22 +19,14 @@ export class RegleActivites implements Regle {
 
     if (!valeur) return;
 
-    if (
-      valeur ===
-      "Fournisseurs de réseaux de communications électroniques publics"
-    )
-      return new RegleActivites(
-        "fournisseurReseauxCommunicationElectroniquesPublics",
-      );
+    const activiteCorrespondante = Object.entries(libellesActivites).find(
+      ([, libelle]) => libelle === valeur,
+    );
 
-    if (
-      valeur ===
-      "Fournisseurs de services de communications électroniques accessibles au public"
-    )
-      return new RegleActivites(
-        "fournisseurServiceCommunicationElectroniquesPublics",
-      );
+    if (!activiteCorrespondante)
+      throw new ErreurLectureDeRegle(valeur, "Activités");
 
-    throw new ErreurLectureDeRegle(valeur, "Activités");
+    const [id] = activiteCorrespondante;
+    return new RegleActivites(id as Activite);
   }
 }

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
@@ -19,6 +19,19 @@ export class RegleActivites implements Regle {
 
     if (!valeur) return;
 
+    if (valeur === "Autre activité") {
+      const secteur = texte["Secteurs"];
+      switch (secteur) {
+        case "Infrastructure numérique":
+          return new RegleActivites("autreActiviteInfrastructureNumerique");
+        default:
+          throw new ErreurLectureDeRegle(
+            `${valeur} pour le secteur ${secteur}`,
+            "Activités",
+          );
+      }
+    }
+
     const activiteCorrespondante = Object.entries(libellesActivites).find(
       ([, libelle]) => libelle === valeur,
     );

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
@@ -19,27 +19,33 @@ export class RegleActivites implements Regle {
 
     if (!valeur) return;
 
-    if (valeur === "Autre activité") {
-      const secteur = texte["Secteurs"];
-      switch (secteur) {
-        case "Infrastructure numérique":
-          return new RegleActivites("autreActiviteInfrastructureNumerique");
-        default:
-          throw new ErreurLectureDeRegle(
-            `${valeur} pour le secteur ${secteur}`,
-            "Activités",
-          );
-      }
-    }
-
-    const activiteCorrespondante = Object.entries(libellesActivites).find(
-      ([, libelle]) => libelle === valeur,
-    );
-
-    if (!activiteCorrespondante)
-      throw new ErreurLectureDeRegle(valeur, "Activités");
-
-    const [id] = activiteCorrespondante;
-    return new RegleActivites(id as Activite);
+    return valeur === "Autre activité"
+      ? recupereAutreActivite(texte)
+      : recupereActiviteIdentifiee(valeur);
   }
 }
+
+const recupereAutreActivite = (texte: SpecificationTexte) => {
+  const secteur = texte["Secteurs"];
+  switch (secteur) {
+    case "Infrastructure numérique":
+      return new RegleActivites("autreActiviteInfrastructureNumerique");
+    default:
+      throw new ErreurLectureDeRegle(
+        `"Autre activité" pour le secteur ${secteur}`,
+        "Activités",
+      );
+  }
+};
+
+const recupereActiviteIdentifiee = (valeur: string) => {
+  const activiteCorrespondante = Object.entries(libellesActivites).find(
+    ([, libelle]) => libelle === valeur,
+  );
+
+  if (!activiteCorrespondante)
+    throw new ErreurLectureDeRegle(valeur, "Activités");
+
+  const [id] = activiteCorrespondante;
+  return new RegleActivites(id as Activite);
+};

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
@@ -26,6 +26,14 @@ export class RegleActivites implements Regle {
         "fournisseurReseauxCommunicationElectroniquesPublics",
       );
 
+    if (
+      valeur ===
+      "Fournisseurs de services de communications électroniques accessibles au public"
+    )
+      return new RegleActivites(
+        "fournisseurServiceCommunicationElectroniquesPublics",
+      );
+
     throw new ErreurLectureDeRegle(valeur, "Activités");
   }
 }

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
@@ -1,0 +1,31 @@
+import { Regle } from "../Specifications.ts";
+import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
+import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
+import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
+import { Activite } from "../../../../../commun/core/src/Domain/Simulateur/Activite.definitions.ts";
+import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
+
+export class RegleActivites implements Regle {
+  constructor(private readonly activite: Activite) {}
+
+  evalue(reponses: EtatQuestionnaire): boolean {
+    const activites = reponses.activites;
+    return contientUnParmi(this.activite)(activites);
+  }
+
+  static nouvelle(texte: SpecificationTexte): RegleActivites | undefined {
+    const valeur = texte["Activités"];
+
+    if (!valeur) return;
+
+    if (
+      valeur ===
+      "Fournisseurs de réseaux de communications électroniques publics"
+    )
+      return new RegleActivites(
+        "fournisseurReseauxCommunicationElectroniquesPublics",
+      );
+
+    throw new ErreurLectureDeRegle(valeur, "Activités");
+  }
+}

--- a/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
+++ b/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Resultat
-Oui;;;;;;Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Resultat
+Oui;;;;;;;Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -457,6 +457,13 @@ describe("La fabrique de spécifications", () => {
         libelleSecteur: "Infrastructure numérique",
         secteur: "infrastructureNumerique",
       },
+      {
+        libelleActivite:
+          "Fournisseurs de services de communications électroniques accessibles au public",
+        activite: "fournisseurServiceCommunicationElectroniquesPublics",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
     ];
 
     it.each(casDeTest)(

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -12,6 +12,7 @@ import { SecteurActivite } from "../../../../commun/core/src/Domain/Simulateur/S
 import { libellesSecteursActivite } from "../../../src/References/LibellesSecteursActivite";
 import { SousSecteurActivite } from "../../../../commun/core/src/Domain/Simulateur/SousSecteurActivite.definitions";
 import { libellesSousSecteursActivite } from "../../../src/References/LibellesSousSecteursActivite";
+import { Activite } from "../../../../commun/core/src/Domain/Simulateur/Activite.definitions";
 
 describe("La fabrique de spécifications", () => {
   let fabrique: FabriqueDeSpecifications;
@@ -437,6 +438,62 @@ describe("La fabrique de spécifications", () => {
           }),
         );
       }).toThrowError("Parachute");
+    });
+  });
+
+  describe("pour la règle « Activités »", () => {
+    type CasDeTest = {
+      libelleActivite: string;
+      activite: Activite;
+      libelleSecteur: string;
+      secteur: SecteurActivite;
+    };
+
+    const casDeTest: CasDeTest[] = [
+      {
+        libelleActivite:
+          "Fournisseurs de réseaux de communications électroniques publics",
+        activite: "fournisseurReseauxCommunicationElectroniquesPublics",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
+    ];
+
+    it.each(casDeTest)(
+      `sait instancier la règle $libelleActivite du secteur $libelleSecteur`,
+      ({ libelleActivite, activite, libelleSecteur, secteur }) => {
+        const specs: Specifications = fabrique.transforme(
+          uneSpecification({
+            Activités: libelleActivite,
+            Secteurs: libelleSecteur,
+            Resultat: "Regule EE",
+          }),
+        );
+
+        const reponse: EtatQuestionnaire = {
+          ...etatParDefaut,
+          secteurActivite: [secteur],
+          activites: [activite],
+        };
+
+        expect(specs.evalue(reponse)).toMatchObject(reguleEE());
+      },
+    );
+
+    it("n'instancie pas de règle si aucune valeur n'est passée", () => {
+      const specs: Specifications = fabrique.transforme(
+        uneSpecification({ Activités: "", Resultat: "Regule EE" }),
+      );
+
+      expect(specs.nombreDeRegles()).toBe(0);
+    });
+
+    it("lève une exception si la valeur reçue n'est pas gérée", () => {
+      expect(() => {
+        fabrique.transforme(
+          uneSpecification({ Activités: "Volley", Resultat: "Regule EE" }),
+        );
+      }).toThrowError("Volley");
     });
   });
 

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -477,6 +477,49 @@ describe("La fabrique de spécifications", () => {
         libelleSecteur: "Infrastructure numérique",
         secteur: "infrastructureNumerique",
       },
+      {
+        libelleActivite:
+          "Fournisseur des services d'enregistrement de noms de domaine",
+        activite: "fournisseurServicesEnregristrementNomDomaine",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
+      {
+        libelleActivite: "Prestataires de service de confiance qualifié",
+        activite: "prestataireServiceConfianceQualifie",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
+      {
+        libelleActivite: "Prestataires de service de confiance non qualifié",
+        activite: "prestataireServiceConfianceNonQualifie",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
+      {
+        libelleActivite: "Fournisseurs de services d'informatique en nuage",
+        activite: "fournisseurServicesInformatiqueNuage",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
+      {
+        libelleActivite: "Fournisseurs de services de centres de données",
+        activite: "fournisseurServiceCentresDonnees",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
+      {
+        libelleActivite: "Fournisseurs de réseaux de diffusion de contenu",
+        activite: "fournisseurReseauxDiffusionContenu",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
+      {
+        libelleActivite: "Fournisseurs de points d'échange internet",
+        activite: "fournisseurPointEchangeInternet",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
     ];
 
     it.each(casDeTest)(

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -471,6 +471,12 @@ describe("La fabrique de spécifications", () => {
         libelleSecteur: "Infrastructure numérique",
         secteur: "infrastructureNumerique",
       },
+      {
+        libelleActivite: "Registres de noms de domaines de premier niveau",
+        activite: "registresNomsDomainesPremierNiveau",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
     ];
 
     it.each(casDeTest)(

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -464,6 +464,13 @@ describe("La fabrique de spécifications", () => {
         libelleSecteur: "Infrastructure numérique",
         secteur: "infrastructureNumerique",
       },
+      {
+        libelleActivite:
+          "Fournisseurs de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines",
+        activite: "fournisseurServicesDNS",
+        libelleSecteur: "Infrastructure numérique",
+        secteur: "infrastructureNumerique",
+      },
     ];
 
     it.each(casDeTest)(

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -512,6 +512,7 @@ function uneSpecification(
     Taille: "",
     Secteurs: "",
     "Sous-secteurs": "",
+    Activités: "",
     Resultat: "CHAQUE TEST DOIT LE DÉFINIR",
     ...surcharge,
   };

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -515,8 +515,8 @@ describe("La fabrique de spécifications", () => {
         secteur: "infrastructureNumerique",
       },
       {
-        libelleActivite: "Fournisseurs de points d'échange internet",
-        activite: "fournisseurPointEchangeInternet",
+        libelleActivite: "Autre activité",
+        activite: "autreActiviteInfrastructureNumerique",
         libelleSecteur: "Infrastructure numérique",
         secteur: "infrastructureNumerique",
       },

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Resultat
-Oui;;;;;;Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Resultat
+Oui;;;;;;;Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Resultat
-Oui;France;;;;;Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Resultat
+Oui;France;;;;;;Regule EE


### PR DESCRIPTION
Cette PR continue sur la trajectoire de « spécification en CSV ».

Cette fois on ajoute la règle sur les Activités.
Pour l'instant seules les activités du secteur « Infrastructure numérique » sont gérées.

Il reste les activités :
 - du secteur « Gestion des services TIC »
 - du secteur « Fournisseur numérique »
 -  « Autre activité » qui devront être gérées par secteur


Ce seront les PR suivantes.