### PR TITLE
[Éligibilité en CSV] Termine la règle « Extra - Fourniture de service »

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
@@ -9,6 +9,7 @@ import { ErreurLectureDeRegle } from "./regles/ErreurLectureDeRegle.ts";
 import { RegleSecteurs } from "./regles/RegleSecteurs.ts";
 import { RegleSousSecteurs } from "./regles/RegleSousSecteurs.ts";
 import { RegleActivites } from "./regles/RegleActivites.ts";
+import { RegleFournitureDeServicesNumerique } from "./regles/RegleFournitureDeServicesNumerique.ts";
 
 export class FabriqueDeSpecifications {
   transforme(texte: SpecificationTexte): Specifications {
@@ -20,6 +21,7 @@ export class FabriqueDeSpecifications {
       RegleSecteurs.nouvelle(texte),
       RegleSousSecteurs.nouvelle(texte),
       RegleActivites.nouvelle(texte),
+      RegleFournitureDeServicesNumerique.nouvelle(texte),
     ].filter((s) => s !== undefined) as Regle[];
 
     const resultat = this.transformeResultat(texte);

--- a/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
@@ -6,6 +6,7 @@ export enum ClesDuCSV {
   "Secteurs",
   "Sous-secteurs",
   "Activités",
+  "Extra - Fourniture de service",
   "Resultat",
 }
 

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleFournitureDeServicesNumerique.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleFournitureDeServicesNumerique.ts
@@ -1,0 +1,35 @@
+import { Regle } from "../Specifications.ts";
+import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
+import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
+import { AppartenancePaysUnionEuropeenne } from "../../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
+import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
+import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
+
+export class RegleFournitureDeServicesNumerique implements Regle {
+  constructor(
+    private readonly localisationsAcceptees: AppartenancePaysUnionEuropeenne[],
+  ) {}
+
+  evalue(reponses: EtatQuestionnaire): boolean {
+    const reponse = reponses.localisationFournitureServicesNumeriques;
+
+    return contientUnParmi(...this.localisationsAcceptees)(reponse);
+  }
+
+  static nouvelle(
+    texte: SpecificationTexte,
+  ): RegleFournitureDeServicesNumerique | undefined {
+    const valeur = texte["Extra - Fourniture de service"];
+
+    if (!valeur) return;
+
+    if (valeur === "France")
+      return new RegleFournitureDeServicesNumerique(["france"]);
+    if (valeur === "Autres États membres de l'Union Européenne")
+      return new RegleFournitureDeServicesNumerique(["autre"]);
+    if (valeur === "Autres États hors Union Européenne")
+      return new RegleFournitureDeServicesNumerique(["horsue"]);
+
+    throw new ErreurLectureDeRegle(valeur, "Extra - Fourniture de service");
+  }
+}

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleFournitureDeServicesNumerique.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleFournitureDeServicesNumerique.ts
@@ -23,13 +23,22 @@ export class RegleFournitureDeServicesNumerique implements Regle {
 
     if (!valeur) return;
 
-    if (valeur === "France")
-      return new RegleFournitureDeServicesNumerique(["france"]);
-    if (valeur === "Autres États membres de l'Union Européenne")
-      return new RegleFournitureDeServicesNumerique(["autre"]);
-    if (valeur === "Autres États hors Union Européenne")
-      return new RegleFournitureDeServicesNumerique(["horsue"]);
+    const morceaux = valeur.split(SEPARATEUR).map((m) => m.trim());
+    const tousConnus = morceaux.every((m) => Object.keys(mapping).includes(m));
 
-    throw new ErreurLectureDeRegle(valeur, "Extra - Fourniture de service");
+    if (!tousConnus)
+      throw new ErreurLectureDeRegle(valeur, "Extra - Fourniture de service");
+
+    return new RegleFournitureDeServicesNumerique(
+      morceaux.map((m) => mapping[m]),
+    );
   }
 }
+
+const mapping: Record<string, AppartenancePaysUnionEuropeenne> = {
+  France: "france",
+  "Autres États membres de l'Union Européenne": "autre",
+  "Autres États hors Union Européenne": "horsue",
+};
+
+const SEPARATEUR = "+";

--- a/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
+++ b/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Resultat
-Oui;;;;;;;Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Resultat
+Oui;;;;;;;;Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -575,6 +575,7 @@ function uneSpecification(
     Secteurs: "",
     "Sous-secteurs": "",
     Activités: "",
+    "Extra - Fourniture de service": "",
     Resultat: "CHAQUE TEST DOIT LE DÉFINIR",
     ...surcharge,
   };

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -7,7 +7,10 @@ import { FabriqueDeSpecifications } from "../../../src/questionnaire/specificati
 import { SpecificationTexte } from "../../../src/questionnaire/specifications/FormatDesSpecificationsCSV";
 import { Specifications } from "../../../src/questionnaire/specifications/Specifications";
 import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions";
-import { UnionPetitMoyenGrand } from "../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions";
+import {
+  AppartenancePaysUnionEuropeenne,
+  UnionPetitMoyenGrand,
+} from "../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions";
 import { SecteurActivite } from "../../../../commun/core/src/Domain/Simulateur/SecteurActivite.definitions";
 import { libellesSecteursActivite } from "../../../src/References/LibellesSecteursActivite";
 import { SousSecteurActivite } from "../../../../commun/core/src/Domain/Simulateur/SousSecteurActivite.definitions";
@@ -499,6 +502,80 @@ describe("La fabrique de spécifications", () => {
           uneSpecification({ Activités: "Volley", Resultat: "Regule EE" }),
         );
       }).toThrowError("Volley");
+    });
+  });
+
+  describe("pour la règle « Extra - Fourniture de service »", () => {
+    const entiteQuiFournitEn = (
+      localisations: AppartenancePaysUnionEuropeenne[],
+    ): EtatQuestionnaire => ({
+      ...etatParDefaut,
+      localisationFournitureServicesNumeriques: localisations,
+    });
+
+    it("instancie une règle pour la valeur « France »", () => {
+      const specsFrance: Specifications = fabrique.transforme(
+        uneSpecification({
+          "Extra - Fourniture de service": "France",
+          Resultat: "Regule EE",
+        }),
+      );
+
+      const enFrance = entiteQuiFournitEn(["france"]);
+
+      expect(specsFrance.nombreDeRegles()).toBe(1);
+      expect(specsFrance.evalue(enFrance)).toMatchObject(reguleEE());
+    });
+
+    it("instancie une règle pour la valeur « Autres États membres de l'Union Européenne »", () => {
+      const specsAutreDansUE: Specifications = fabrique.transforme(
+        uneSpecification({
+          "Extra - Fourniture de service":
+            "Autres États membres de l'Union Européenne",
+          Resultat: "Regule EE",
+        }),
+      );
+
+      const autreEnUE = entiteQuiFournitEn(["autre"]);
+
+      expect(specsAutreDansUE.nombreDeRegles()).toBe(1);
+      expect(specsAutreDansUE.evalue(autreEnUE)).toMatchObject(reguleEE());
+    });
+
+    it("instancie une règle pour la valeur « Autres États hors Union Européenne »", () => {
+      const specsHorsUE: Specifications = fabrique.transforme(
+        uneSpecification({
+          "Extra - Fourniture de service": "Autres États hors Union Européenne",
+          Resultat: "Regule EE",
+        }),
+      );
+
+      const horsUE = entiteQuiFournitEn(["horsue"]);
+
+      expect(specsHorsUE.nombreDeRegles()).toBe(1);
+      expect(specsHorsUE.evalue(horsUE)).toMatchObject(reguleEE());
+    });
+
+    it("n'instancie pas de règle si aucune valeur n'est passée", () => {
+      const specs: Specifications = fabrique.transforme(
+        uneSpecification({
+          "Extra - Fourniture de service": "",
+          Resultat: "Regule EE",
+        }),
+      );
+
+      expect(specs.nombreDeRegles()).toBe(0);
+    });
+
+    it("lève une exception si la valeur reçue n'est pas gérée", () => {
+      expect(() => {
+        fabrique.transforme(
+          uneSpecification({
+            "Extra - Fourniture de service": "Jardin",
+            Resultat: "Regule EE",
+          }),
+        );
+      }).toThrowError("Jardin");
     });
   });
 

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -556,6 +556,33 @@ describe("La fabrique de spécifications", () => {
       expect(specsHorsUE.evalue(horsUE)).toMatchObject(reguleEE());
     });
 
+    describe("lorsque la valeur est un cumul de réponses", () => {
+      it("instancie la règle en prenant en compte chaque réponse individuelle", () => {
+        const specsFranceEtUE = fabrique.transforme(
+          uneSpecification({
+            "Extra - Fourniture de service":
+              "France + Autres États membres de l'Union Européenne",
+            Resultat: "Regule EE",
+          }),
+        );
+
+        expect(specsFranceEtUE.nombreDeRegles()).toBe(1);
+
+        expect(
+          specsFranceEtUE.evalue(entiteQuiFournitEn(["france"])),
+        ).toMatchObject(reguleEE());
+        expect(
+          specsFranceEtUE.evalue(entiteQuiFournitEn(["autre"])),
+        ).toMatchObject(reguleEE());
+        expect(
+          specsFranceEtUE.evalue(entiteQuiFournitEn(["france", "horsue"])),
+        ).toMatchObject(reguleEE());
+        expect(specsFranceEtUE.evalue(entiteQuiFournitEn(["horsue"]))).toBe(
+          undefined,
+        );
+      });
+    });
+
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specs: Specifications = fabrique.transforme(
         uneSpecification({

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Resultat
-Oui;;;;;;;Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Resultat
+Oui;;;;;;;;Regule EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Resultat
-Oui;France;;;;;;Regule EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Resultat
+Oui;France;;;;;;;Regule EE


### PR DESCRIPTION
Cette PR ajoute l'implémentation de la règle qui gère la colonne « Extra - Fourniture de service » du CSV.

La règle est simple. Pas de complexité particulière.