### PR TITLE
[Éligibilité en CSV] Lecture d'un CSV de PROD

### DIFF
--- a/anssi-nis2-ui/src/References/LibellesActivites.ts
+++ b/anssi-nis2-ui/src/References/LibellesActivites.ts
@@ -210,22 +210,21 @@ export const libellesActivites: Record<Activite, string> = {
     "Fabrication de produits électroniques grand public",
   fabriquantProduitsInformatiquesElectroniquesOptiques:
     "Fabrication de produits informatiques, électroniques et optiques",
-  fournisseurPointEchangeInternet: "Fournisseurs de points d'échange internet",
+  fournisseurPointEchangeInternet: "Fournisseur de points d'échange internet",
   fournisseurReseauxCommunicationElectroniquesPublics:
-    "Fournisseurs de réseaux de communications électroniques publics",
+    "Fournisseur de réseaux de communications électroniques publics",
   fournisseurReseauxDiffusionContenu:
-    "Fournisseurs de réseaux de diffusion de contenu",
+    "Fournisseur de réseaux de diffusion de contenu",
   fournisseurServiceCentresDonnees:
-    "Fournisseurs de services de centres de données",
+    "Fournisseur de services de centres de données",
   fournisseurServiceCommunicationElectroniquesPublics:
-    "Fournisseurs de services de communications électroniques accessibles au public",
+    "Fournisseur de services de communications électroniques accessibles au public",
   fournisseurServicesDNS:
-    "Fournisseurs de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines",
-  fournisseurServicesGeres: "Fournisseurs de services gérés",
+    "Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines",
+  fournisseurServicesGeres: "Fournisseur de services gérés",
   fournisseurServicesInformatiqueNuage:
-    "Fournisseurs de services d'informatique en nuage",
-  fournisseurServicesSecuriteGeres:
-    "Fournisseurs de services de sécurité gérés",
+    "Fournisseur de services d'informatique en nuage",
+  fournisseurServicesSecuriteGeres: "Fournisseur de services de sécurité gérés",
   fournisseursDistributeursEauxConsommation:
     "Fournisseurs et distributeurs d'eaux destinées à la consommation " +
     "humaine, à l'exclusion des distributeurs pour lesquels la distribution " +
@@ -233,10 +232,10 @@ export const libellesActivites: Record<Activite, string> = {
     "essentielle de leur activité générale de distribution d'autres produits " +
     "et biens",
   fournisseursMoteursRechercheEnLigne:
-    "Fournisseurs de moteurs de recherche en ligne",
-  fournisseursPlaceMarcheEnLigne: "Fournisseurs de places de marché en ligne",
+    "Fournisseur de moteurs de recherche en ligne",
+  fournisseursPlaceMarcheEnLigne: "Fournisseur de places de marché en ligne",
   fournisseursPlateformesServicesReseauxSociaux:
-    "Fournisseurs de plateformes de services de réseaux sociaux",
+    "Fournisseur de plateformes de services de réseaux sociaux",
   fournisseurServicesEnregristrementNomDomaine:
     "Fournisseur des services d'enregistrement de noms de domaine",
   gestionnaireInfrastructure: "Gestionnaires des infrastructures",
@@ -252,9 +251,9 @@ export const libellesActivites: Record<Activite, string> = {
     "Opérateurs de réseaux de chaleur ou de réseaux de froid",
   organismeRecherche: "Organismes de recherche",
   prestataireServiceConfianceQualifie:
-    "Prestataires de service de confiance qualifié",
+    "Prestataire de service de confiance qualifié",
   prestataireServiceConfianceNonQualifie:
-    "Prestataires de service de confiance non qualifié",
+    "Prestataire de service de confiance non qualifié",
   prestataireSoinsSante: "Prestataires de soins de santé",
   prestatairesServicesPostauxExpedition:
     "Prestataires de services postaux, y compris les prestataires de " +
@@ -264,7 +263,7 @@ export const libellesActivites: Record<Activite, string> = {
     "Entités exerçant des activités de recherche et de développement dans le " +
     "domaine des médicaments",
   registresNomsDomainesPremierNiveau:
-    "Registres de noms de domaines de premier niveau",
+    "Registre de noms de domaines de premier niveau",
   secteurAlimentaireDistributionGrosProductionTransformationIndustrielle:
     "Entreprises du secteur alimentaire qui exercent des activités de " +
     "distribution en gros ainsi que de production et de transformation " +

--- a/anssi-nis2-ui/src/References/LibellesSousSecteursActivite.ts
+++ b/anssi-nis2-ui/src/References/LibellesSousSecteursActivite.ts
@@ -21,11 +21,11 @@ export const libellesSousSecteurFabrication: DetailsSousSecteurUnique<SousSecteu
     constructionVehiculesAutomobiles:
       "Construction de véhicules automobiles, remorques et semi- remorques",
     fabricationAutresMaterielTransports:
-      "Fabrication d’autres matériels de transport",
+      "Fabrication d'autres matériels de transport",
     fabricationDispositifsMedicaux:
       "Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro",
     fabricationEquipementsElectroniques:
-      "Fabrication d’équipements électriques",
+      "Fabrication d'équipements électriques", // Ici, on note une coquille entre le libellé 'électrique' et l'ID 'Electronique'
     fabricationProduitsInformatiquesElectroniquesOptiques:
       "Fabrication de produits informatiques, électroniques et optiques",
     fabricationMachinesEquipements:

--- a/anssi-nis2-ui/src/References/ListeDescriptionsActivites.ts
+++ b/anssi-nis2-ui/src/References/ListeDescriptionsActivites.ts
@@ -457,14 +457,6 @@ export const listeDescriptionsActivites: Record<
         "Un fournisseur de services gérés qui effectue ou fournit une assistance pour des activités liées à la gestion " +
         "des risques en matière de cybersécurité.",
     },
-    {
-      titre: "Fournisseur de services gérés",
-      description:
-        "Une entité qui fournit des services liés à l’installation, à la gestion, à l’exploitation " +
-        "ou à l’entretien de produits, de réseaux, d’infrastructures ou d’applications TIC ou d’autres " +
-        "réseaux et systèmes d’information, par l’intermédiaire d’une assistance ou d’une administration " +
-        "active, soit dans les locaux des clients, soit à distance.",
-    },
   ],
   fournisseursDistributeursEauxConsommation: [
     {

--- a/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
@@ -32,35 +32,35 @@ export class FabriqueDeSpecifications {
   private transformeResultat(texte: SpecificationTexte): ResultatEligibilite {
     const valeur = texte["Resultat"];
 
-    if (valeur === "Regule EE")
+    if (valeur === "Régulée EE")
       return {
         regulation: "Regule",
         typeEntite: "EntiteEssentielle",
         pointsAttention: { precisions: [], resumes: [] },
       };
 
-    if (valeur === "Regule EI")
+    if (valeur === "Régulée EI")
       return {
         regulation: "Regule",
         typeEntite: "EntiteImportante",
         pointsAttention: { precisions: [], resumes: [] },
       };
 
-    if (valeur === "Regule enregistrement seul")
+    if (valeur === "Régulée, enregistrement seul")
       return {
         regulation: "Regule",
         typeEntite: "EnregistrementUniquement",
         pointsAttention: { precisions: [], resumes: [] },
       };
 
-    if (valeur === "Regule autre EM")
+    if (valeur === "Régulée, sans précision EE/EI")
       return {
         regulation: "Regule",
         typeEntite: "AutreEtatMembreUE",
         pointsAttention: { precisions: [], resumes: [] },
       };
 
-    if (valeur === "Non regule")
+    if (valeur === "Non régulée")
       return {
         regulation: "NonRegule",
         typeEntite: "AutreEtatMembreUE", // Le type est sans importance ici.

--- a/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
@@ -5,6 +5,8 @@ export interface Regle {
   evalue(reponses: EtatQuestionnaire): boolean;
 }
 
+export const estValeurVide = (v: string) => v === "-";
+
 export class Specifications {
   constructor(
     private readonly regles: Regle[],

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
@@ -1,4 +1,4 @@
-import { Regle } from "../Specifications.ts";
+import { estValeurVide, Regle } from "../Specifications.ts";
 import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
 import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
 import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
@@ -17,7 +17,7 @@ export class RegleActivites implements Regle {
   static nouvelle(texte: SpecificationTexte): RegleActivites | undefined {
     const valeur = texte["Activités"];
 
-    if (!valeur) return;
+    if (estValeurVide(valeur)) return;
 
     return valeur === "Autre activité"
       ? recupereAutreActivite(texte)
@@ -62,6 +62,10 @@ const mappingFabrication: Record<string, Activite> = {
     "autreActiviteFabricationProduitsInformatiquesElectroniquesOptiques",
   "Fabrication de machines et équipements n.c.a.":
     "autreActiviteFabricationMachinesEquipements",
+  "Fabrication d'équipements électriques":
+    "autreActiviteFabricationEquipementsElectroniques",
+  "Fabrication d'autres matériels de transport":
+    "autreActiviteConstructionVehiculesAutomobilesRemorquesSemi",
 };
 
 const mappingTransports: Record<string, Activite> = {

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleEntiteOSE.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleEntiteOSE.ts
@@ -21,6 +21,7 @@ export class RegleEntiteOSE implements Regle {
 
     if (!valeur) return;
     if (valeur === "Oui") return new RegleEntiteOSE(["oui"]);
+    if (valeur === "Non") return new RegleEntiteOSE(["non"]);
     if (valeur === "Non / Ne sait pas")
       return new RegleEntiteOSE(["non", "nsp"]);
 

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleFournitureDeServicesNumerique.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleFournitureDeServicesNumerique.ts
@@ -1,4 +1,4 @@
-import { Regle } from "../Specifications.ts";
+import { estValeurVide, Regle } from "../Specifications.ts";
 import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
 import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
 import { AppartenancePaysUnionEuropeenne } from "../../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
@@ -21,7 +21,7 @@ export class RegleFournitureDeServicesNumerique implements Regle {
   ): RegleFournitureDeServicesNumerique | undefined {
     const valeur = texte["Extra - Fourniture de service"];
 
-    if (!valeur) return;
+    if (estValeurVide(valeur)) return;
 
     const morceaux = valeur.split(SEPARATEUR).map((m) => m.trim());
     const tousConnus = morceaux.every((m) => Object.keys(mapping).includes(m));

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleLocalisation.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleLocalisation.ts
@@ -1,7 +1,7 @@
 import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
 import { AppartenancePaysUnionEuropeenne } from "../../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
-import { Regle } from "../Specifications.ts";
+import { estValeurVide, Regle } from "../Specifications.ts";
 import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
 import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
 
@@ -19,7 +19,7 @@ export class RegleLocalisation implements Regle {
   static nouvelle(texte: SpecificationTexte): RegleLocalisation | undefined {
     const valeur = texte["Localisation"];
 
-    if (!valeur) return;
+    if (estValeurVide(valeur)) return;
     if (valeur === "France") return new RegleLocalisation("france");
 
     throw new ErreurLectureDeRegle(valeur, "Localisation");

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleSecteurs.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleSecteurs.ts
@@ -1,5 +1,5 @@
 import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
-import { Regle } from "../Specifications.ts";
+import { estValeurVide, Regle } from "../Specifications.ts";
 import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
 import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
 import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
@@ -17,7 +17,7 @@ export class RegleSecteurs implements Regle {
   static nouvelle(texte: SpecificationTexte): RegleSecteurs | undefined {
     const secteurAttendu = texte["Secteurs"];
 
-    if (!secteurAttendu) return;
+    if (estValeurVide(secteurAttendu)) return;
 
     const secteur = Object.entries(libellesSecteursActivite).find(
       ([, valeur]) => valeur == secteurAttendu,

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleSousSecteurs.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleSousSecteurs.ts
@@ -1,5 +1,5 @@
 import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
-import { Regle } from "../Specifications.ts";
+import { estValeurVide, Regle } from "../Specifications.ts";
 import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
 import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
 import { libellesSousSecteursActivite } from "../../../References/LibellesSousSecteursActivite.ts";
@@ -17,7 +17,7 @@ export class RegleSousSecteurs implements Regle {
   static nouvelle(texte: SpecificationTexte): RegleSousSecteurs | undefined {
     const sousSecteurAttendu = texte["Sous-secteurs"];
 
-    if (!sousSecteurAttendu) return;
+    if (estValeurVide(sousSecteurAttendu)) return;
 
     return sousSecteurAttendu === "Autre sous-secteur"
       ? chercheSousSecteurAutre(texte["Secteurs"])

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleTaille.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleTaille.ts
@@ -1,5 +1,5 @@
 import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
-import { Regle } from "../Specifications.ts";
+import { estValeurVide, Regle } from "../Specifications.ts";
 import { UnionPetitMoyenGrand } from "../../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
 import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
@@ -36,7 +36,7 @@ export class RegleTaille implements Regle {
   static nouvelle(texte: SpecificationTexte): RegleTaille | undefined {
     const valeur = texte["Taille"];
 
-    if (!valeur) return;
+    if (estValeurVide(valeur)) return;
     if (valeur === "Petite") return new RegleTaille("petit");
     if (valeur === "Moyenne") return new RegleTaille("moyen");
     if (valeur === "Grande") return new RegleTaille("grand");

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleTypeDeStructure.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleTypeDeStructure.ts
@@ -1,4 +1,4 @@
-import { Regle } from "../Specifications.ts";
+import { estValeurVide, Regle } from "../Specifications.ts";
 import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
 import { TypeStructure } from "../../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
@@ -15,8 +15,8 @@ export class RegleTypeDeStructure implements Regle {
   static nouvelle(texte: SpecificationTexte): RegleTypeDeStructure | undefined {
     const valeur = texte["Type de structure"];
 
-    if (!valeur) return;
-    if (valeur === "Entreprise privee ou publique")
+    if (estValeurVide(valeur)) return;
+    if (valeur === "Entreprise privée ou publique")
       return new RegleTypeDeStructure("privee");
 
     throw new ErreurLectureDeRegle(valeur, "Type de structure");

--- a/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
+++ b/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
@@ -1,2 +1,2 @@
 Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Resultat
-Oui;;;;;;;;Regule EE
+Oui;-;-;-;-;-;-;-;Régulée EE

--- a/anssi-nis2-ui/src/stories/utilitaires/Simulateur.actions.ts
+++ b/anssi-nis2-ui/src/stories/utilitaires/Simulateur.actions.ts
@@ -28,7 +28,7 @@ export const passeEtapeEnCochant = async <
   for (let i = 0; i < champsACliquer.length; i++) {
     const [champ, valeur] = champsACliquer[i];
     verifieEtatBoutonSuivant(suivantActiveApres, boutonSuivant);
-    const champACliquer = await canvas.findByText(
+    const champACliquer = await canvas.findByLabelText(
       libellesValeurDeChamp(champ, valeur),
     );
     await userEvent.click(champACliquer);

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -46,7 +46,7 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier une règle « Oui »", () => {
       const specs = fabrique.transforme(
-        uneSpecification({ "Designation OSE": "Oui", Resultat: "Regule EE" }),
+        uneSpecification({ "Designation OSE": "Oui", Resultat: "Régulée EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
@@ -55,11 +55,22 @@ describe("La fabrique de spécifications", () => {
       expect(specs.evalue(entiteNeSaitPas)).toBe(undefined);
     });
 
+    it("sait instancier une règle « Non »", () => {
+      const specs = fabrique.transforme(
+        uneSpecification({ "Designation OSE": "Non", Resultat: "Régulée EE" }),
+      );
+
+      expect(specs.nombreDeRegles()).toBe(1);
+      expect(specs.evalue(entiteOui)).toBe(undefined);
+      expect(specs.evalue(entiteNon)).toMatchObject(reguleEE());
+      expect(specs.evalue(entiteNeSaitPas)).toBe(undefined);
+    });
+
     it("sait instancier une règle « Non / Ne sait pas »", () => {
       const specs = fabrique.transforme(
         uneSpecification({
           "Designation OSE": "Non / Ne sait pas",
-          Resultat: "Regule EE",
+          Resultat: "Régulée EE",
         }),
       );
 
@@ -79,7 +90,7 @@ describe("La fabrique de spécifications", () => {
 
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specifications = fabrique.transforme(
-        uneSpecification({ "Designation OSE": "", Resultat: "Regule EE" }),
+        uneSpecification({ "Designation OSE": "", Resultat: "Régulée EE" }),
       );
 
       expect(specifications.nombreDeRegles()).toBe(0);
@@ -98,7 +109,7 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier une règle « France »", () => {
       const specs = fabrique.transforme(
-        uneSpecification({ Localisation: "France", Resultat: "Regule EE" }),
+        uneSpecification({ Localisation: "France", Resultat: "Régulée EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
@@ -114,7 +125,7 @@ describe("La fabrique de spécifications", () => {
 
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specifications = fabrique.transforme(
-        uneSpecification({ Localisation: "", Resultat: "Regule EE" }),
+        uneSpecification({ Localisation: "-", Resultat: "Régulée EE" }),
       );
 
       expect(specifications.nombreDeRegles()).toBe(0);
@@ -131,11 +142,11 @@ describe("La fabrique de spécifications", () => {
       typeStructure: ["publique"],
     };
 
-    it("instancie une règle « Entreprise privee ou publique »", () => {
+    it("instancie une règle « Entreprise privée ou publique »", () => {
       const specs: Specifications = fabrique.transforme(
         uneSpecification({
-          "Type de structure": "Entreprise privee ou publique",
-          Resultat: "Regule EE",
+          "Type de structure": "Entreprise privée ou publique",
+          Resultat: "Régulée EE",
         }),
       );
 
@@ -147,8 +158,8 @@ describe("La fabrique de spécifications", () => {
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specs: Specifications = fabrique.transforme(
         uneSpecification({
-          "Type de structure": "",
-          Resultat: "Regule EE",
+          "Type de structure": "-",
+          Resultat: "Régulée EE",
         }),
       );
 
@@ -158,7 +169,10 @@ describe("La fabrique de spécifications", () => {
     it("lève une exception si la valeur reçue n'est pas gérée", () => {
       expect(() => {
         fabrique.transforme(
-          uneSpecification({ "Type de structure": "X", Resultat: "Regule EE" }),
+          uneSpecification({
+            "Type de structure": "X",
+            Resultat: "Régulée EE",
+          }),
         );
       }).toThrowError("X");
     });
@@ -177,7 +191,7 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier une règle « Petite »", () => {
       const specs = fabrique.transforme(
-        uneSpecification({ Taille: "Petite", Resultat: "Regule EE" }),
+        uneSpecification({ Taille: "Petite", Resultat: "Régulée EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
@@ -188,7 +202,7 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier une règle « Moyenne »", () => {
       const specs = fabrique.transforme(
-        uneSpecification({ Taille: "Moyenne", Resultat: "Regule EE" }),
+        uneSpecification({ Taille: "Moyenne", Resultat: "Régulée EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
@@ -199,7 +213,7 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier une règle « Grande »", () => {
       const specs = fabrique.transforme(
-        uneSpecification({ Taille: "Grande", Resultat: "Regule EE" }),
+        uneSpecification({ Taille: "Grande", Resultat: "Régulée EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(1);
@@ -210,7 +224,7 @@ describe("La fabrique de spécifications", () => {
 
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specs: Specifications = fabrique.transforme(
-        uneSpecification({ Taille: "", Resultat: "Regule EE" }),
+        uneSpecification({ Taille: "-", Resultat: "Régulée EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(0);
@@ -219,7 +233,7 @@ describe("La fabrique de spécifications", () => {
     it("lève une exception si la valeur reçue n'est pas gérée", () => {
       expect(() => {
         fabrique.transforme(
-          uneSpecification({ Taille: "XXL", Resultat: "Regule EE" }),
+          uneSpecification({ Taille: "XXL", Resultat: "Régulée EE" }),
         );
       }).toThrowError("XXL");
     });
@@ -246,7 +260,7 @@ describe("La fabrique de spécifications", () => {
       ({ id, libelle }: { id: SecteurActivite; libelle: string }) => {
         const entite = entiteDuSecteur(id);
         const specs = fabrique.transforme(
-          uneSpecification({ Secteurs: libelle, Resultat: "Regule EE" }),
+          uneSpecification({ Secteurs: libelle, Resultat: "Régulée EE" }),
         );
 
         expect(specs.nombreDeRegles()).toBe(1);
@@ -257,7 +271,7 @@ describe("La fabrique de spécifications", () => {
     it("ne matche pas un secteur qui n'est pas celui de la règle", () => {
       const banque = entiteDuSecteur("banqueSecteurBancaire");
       const specsEnergie = fabrique.transforme(
-        uneSpecification({ Secteurs: "Énergie", Resultat: "Regule EE" }),
+        uneSpecification({ Secteurs: "Énergie", Resultat: "Régulée EE" }),
       );
 
       const resultat = specsEnergie.evalue(banque);
@@ -271,7 +285,7 @@ describe("La fabrique de spécifications", () => {
         "energie",
       ]);
       const specsEnergie = fabrique.transforme(
-        uneSpecification({ Secteurs: "Énergie", Resultat: "Regule EE" }),
+        uneSpecification({ Secteurs: "Énergie", Resultat: "Régulée EE" }),
       );
 
       const resultat = specsEnergie.evalue(banqueEtEnergie);
@@ -281,7 +295,7 @@ describe("La fabrique de spécifications", () => {
 
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specs: Specifications = fabrique.transforme(
-        uneSpecification({ Secteurs: "", Resultat: "Regule EE" }),
+        uneSpecification({ Secteurs: "-", Resultat: "Régulée EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(0);
@@ -290,7 +304,7 @@ describe("La fabrique de spécifications", () => {
     it("lève une exception si la valeur reçue n'est pas gérée", () => {
       expect(() => {
         fabrique.transforme(
-          uneSpecification({ Secteurs: "Tennis", Resultat: "Regule EE" }),
+          uneSpecification({ Secteurs: "Tennis", Resultat: "Régulée EE" }),
         );
       }).toThrowError("Tennis");
     });
@@ -320,7 +334,10 @@ describe("La fabrique de spécifications", () => {
       ({ id, libelle }: { id: SousSecteurActivite; libelle: string }) => {
         const entite = entiteDuSousSecteur(id);
         const specs = fabrique.transforme(
-          uneSpecification({ "Sous-secteurs": libelle, Resultat: "Regule EE" }),
+          uneSpecification({
+            "Sous-secteurs": libelle,
+            Resultat: "Régulée EE",
+          }),
         );
 
         expect(specs.nombreDeRegles()).toBe(1);
@@ -331,7 +348,10 @@ describe("La fabrique de spécifications", () => {
     it("ne matche pas un sous-secteur qui n'est pas celui de la règle", () => {
       const gaz = entiteDuSousSecteur("gaz");
       const transportAerien = fabrique.transforme(
-        uneSpecification({ "Sous-secteurs": "Aériens", Resultat: "Regule EE" }),
+        uneSpecification({
+          "Sous-secteurs": "Aériens",
+          Resultat: "Régulée EE",
+        }),
       );
 
       const resultat = transportAerien.evalue(gaz);
@@ -347,7 +367,7 @@ describe("La fabrique de spécifications", () => {
       const specsFeroviaires = fabrique.transforme(
         uneSpecification({
           "Sous-secteurs": "Ferroviaires",
-          Resultat: "Regule EE",
+          Resultat: "Régulée EE",
         }),
       );
 
@@ -367,7 +387,7 @@ describe("La fabrique de spécifications", () => {
           uneSpecification({
             Secteurs: "Énergie",
             "Sous-secteurs": "Autre sous-secteur",
-            Resultat: "Regule EE",
+            Resultat: "Régulée EE",
           }),
         );
 
@@ -387,7 +407,7 @@ describe("La fabrique de spécifications", () => {
           uneSpecification({
             Secteurs: "Fabrication",
             "Sous-secteurs": "Autre sous-secteur",
-            Resultat: "Regule EE",
+            Resultat: "Régulée EE",
           }),
         );
 
@@ -407,7 +427,7 @@ describe("La fabrique de spécifications", () => {
           uneSpecification({
             Secteurs: "Transports",
             "Sous-secteurs": "Autre sous-secteur",
-            Resultat: "Regule EE",
+            Resultat: "Régulée EE",
           }),
         );
 
@@ -423,7 +443,7 @@ describe("La fabrique de spécifications", () => {
             uneSpecification({
               "Sous-secteurs": "Autre sous-secteur",
               Secteurs: "Gestion des services TIC", // Ce secteur n'a pas de sous-secteur
-              Resultat: "Regule EE",
+              Resultat: "Régulée EE",
             }),
           );
         }).toThrowError("Autre sous-secteur");
@@ -432,7 +452,7 @@ describe("La fabrique de spécifications", () => {
 
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specs: Specifications = fabrique.transforme(
-        uneSpecification({ "Sous-secteurs": "", Resultat: "Regule EE" }),
+        uneSpecification({ "Sous-secteurs": "-", Resultat: "Régulée EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(0);
@@ -443,7 +463,7 @@ describe("La fabrique de spécifications", () => {
         fabrique.transforme(
           uneSpecification({
             "Sous-secteurs": "Parachute",
-            Resultat: "Regule EE",
+            Resultat: "Régulée EE",
           }),
         );
       }).toThrowError("Parachute");
@@ -465,7 +485,7 @@ describe("La fabrique de spécifications", () => {
         activite,
         libelleSecteur,
         secteur,
-        libelleSousSecteur,
+        libelleSousSecteur = "-",
         sousSecteur,
       }) => {
         const specs: Specifications = fabrique.transforme(
@@ -473,7 +493,7 @@ describe("La fabrique de spécifications", () => {
             Activités: libelleActivite,
             Secteurs: libelleSecteur,
             "Sous-secteurs": libelleSousSecteur,
-            Resultat: "Regule EE",
+            Resultat: "Régulée EE",
           }),
         );
 
@@ -490,7 +510,7 @@ describe("La fabrique de spécifications", () => {
 
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specs: Specifications = fabrique.transforme(
-        uneSpecification({ Activités: "", Resultat: "Regule EE" }),
+        uneSpecification({ Activités: "-", Resultat: "Régulée EE" }),
       );
 
       expect(specs.nombreDeRegles()).toBe(0);
@@ -499,7 +519,7 @@ describe("La fabrique de spécifications", () => {
     it("lève une exception si la valeur reçue n'est pas gérée", () => {
       expect(() => {
         fabrique.transforme(
-          uneSpecification({ Activités: "Volley", Resultat: "Regule EE" }),
+          uneSpecification({ Activités: "Volley", Resultat: "Régulée EE" }),
         );
       }).toThrowError("Volley");
     });
@@ -517,7 +537,7 @@ describe("La fabrique de spécifications", () => {
       const specsFrance: Specifications = fabrique.transforme(
         uneSpecification({
           "Extra - Fourniture de service": "France",
-          Resultat: "Regule EE",
+          Resultat: "Régulée EE",
         }),
       );
 
@@ -532,7 +552,7 @@ describe("La fabrique de spécifications", () => {
         uneSpecification({
           "Extra - Fourniture de service":
             "Autres États membres de l'Union Européenne",
-          Resultat: "Regule EE",
+          Resultat: "Régulée EE",
         }),
       );
 
@@ -546,7 +566,7 @@ describe("La fabrique de spécifications", () => {
       const specsHorsUE: Specifications = fabrique.transforme(
         uneSpecification({
           "Extra - Fourniture de service": "Autres États hors Union Européenne",
-          Resultat: "Regule EE",
+          Resultat: "Régulée EE",
         }),
       );
 
@@ -562,7 +582,7 @@ describe("La fabrique de spécifications", () => {
           uneSpecification({
             "Extra - Fourniture de service":
               "France + Autres États membres de l'Union Européenne",
-            Resultat: "Regule EE",
+            Resultat: "Régulée EE",
           }),
         );
 
@@ -586,8 +606,8 @@ describe("La fabrique de spécifications", () => {
     it("n'instancie pas de règle si aucune valeur n'est passée", () => {
       const specs: Specifications = fabrique.transforme(
         uneSpecification({
-          "Extra - Fourniture de service": "",
-          Resultat: "Regule EE",
+          "Extra - Fourniture de service": "-",
+          Resultat: "Régulée EE",
         }),
       );
 
@@ -599,7 +619,7 @@ describe("La fabrique de spécifications", () => {
         fabrique.transforme(
           uneSpecification({
             "Extra - Fourniture de service": "Jardin",
-            Resultat: "Regule EE",
+            Resultat: "Régulée EE",
           }),
         );
       }).toThrowError("Jardin");
@@ -609,7 +629,7 @@ describe("La fabrique de spécifications", () => {
   describe("pour le résultat", () => {
     it("sait instancier un résultat « Régulée EE»", () => {
       const specs: Specifications = fabrique.transforme(
-        uneSpecification({ Resultat: "Regule EE" }),
+        uneSpecification({ Resultat: "Régulée EE" }),
       );
 
       expect(specs.resultat().regulation).toBe("Regule");
@@ -618,25 +638,25 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier un résultat « Régulée EI »", () => {
       const specs: Specifications = fabrique.transforme(
-        uneSpecification({ Resultat: "Regule EI" }),
+        uneSpecification({ Resultat: "Régulée EI" }),
       );
 
       expect(specs.resultat().regulation).toBe("Regule");
       expect(specs.resultat().typeEntite).toBe("EntiteImportante");
     });
 
-    it("sait instancier un résultat « Régulée EI »", () => {
+    it("sait instancier un résultat « Régulée, enregistrement seul »", () => {
       const specs: Specifications = fabrique.transforme(
-        uneSpecification({ Resultat: "Regule enregistrement seul" }),
+        uneSpecification({ Resultat: "Régulée, enregistrement seul" }),
       );
 
       expect(specs.resultat().regulation).toBe("Regule");
       expect(specs.resultat().typeEntite).toBe("EnregistrementUniquement");
     });
 
-    it("sait instancier un résultat « Régulée Autre Etat Membre »", () => {
+    it("sait instancier un résultat « Régulée, sans précision EE/EI »", () => {
       const specs: Specifications = fabrique.transforme(
-        uneSpecification({ Resultat: "Regule autre EM" }),
+        uneSpecification({ Resultat: "Régulée, sans précision EE/EI" }),
       );
 
       expect(specs.resultat().regulation).toBe("Regule");
@@ -645,7 +665,7 @@ describe("La fabrique de spécifications", () => {
 
     it("sait instancier un résultat « Non regulée »", () => {
       const specs: Specifications = fabrique.transforme(
-        uneSpecification({ Resultat: "Non regule" }),
+        uneSpecification({ Resultat: "Non régulée" }),
       );
 
       expect(specs.resultat().regulation).toBe("NonRegule");
@@ -673,13 +693,13 @@ function uneSpecification(
 ): SpecificationTexte {
   return {
     "Designation OSE": "",
-    Localisation: "",
-    "Type de structure": "",
-    Taille: "",
-    Secteurs: "",
-    "Sous-secteurs": "",
-    Activités: "",
-    "Extra - Fourniture de service": "",
+    Localisation: "-",
+    "Type de structure": "-",
+    Taille: "-",
+    Secteurs: "-",
+    "Sous-secteurs": "-",
+    Activités: "-",
+    "Extra - Fourniture de service": "-",
     Resultat: "CHAQUE TEST DOIT LE DÉFINIR",
     ...surcharge,
   };

--- a/anssi-nis2-ui/test/questionnaire/specifications/LeTestDeLaSpecificationCompleteEnCsv.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/LeTestDeLaSpecificationCompleteEnCsv.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { leCSV } from "./aidesAuxTests";
+import { LecteurDeSpecifications } from "../../../src/questionnaire/specifications/LecteurDeSpecifications";
+
+describe("La lecture de la spécification complète en CSV", () => {
+  it("se fait sans problème", () => {
+    const lecteur = new LecteurDeSpecifications();
+    const csv = leCSV("specs-completes-de-travail.csv");
+
+    const specifications = lecteur.lis(csv);
+
+    expect(specifications.length).toBe(284);
+  });
+});

--- a/anssi-nis2-ui/test/questionnaire/specifications/casDeTests.activites.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/casDeTests.activites.ts
@@ -281,6 +281,22 @@ export const autresActivites: CasDeTest[] = [
   },
   {
     libelleActivite: "Autre activité",
+    activite: "autreActiviteFabricationEquipementsElectroniques",
+    libelleSecteur: "Fabrication",
+    secteur: "fabrication",
+    libelleSousSecteur: "Fabrication d'équipements électriques",
+    sousSecteur: "fabricationEquipementsElectroniques",
+  },
+  {
+    libelleActivite: "Autre activité",
+    activite: "autreActiviteConstructionVehiculesAutomobilesRemorquesSemi",
+    libelleSecteur: "Fabrication",
+    secteur: "fabrication",
+    libelleSousSecteur: "Fabrication d'autres matériels de transport",
+    sousSecteur: "fabricationAutresMaterielTransports",
+  },
+  {
+    libelleActivite: "Autre activité",
     activite: "autreActiviteTransportsAeriens",
     libelleSecteur: "Transports",
     secteur: "transports",

--- a/anssi-nis2-ui/test/questionnaire/specifications/casDeTests.activites.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/casDeTests.activites.ts
@@ -14,27 +14,27 @@ export type CasDeTest = {
 export const infrastructureNumerique: CasDeTest[] = [
   {
     libelleActivite:
-      "Fournisseurs de réseaux de communications électroniques publics",
+      "Fournisseur de réseaux de communications électroniques publics",
     activite: "fournisseurReseauxCommunicationElectroniquesPublics",
     libelleSecteur: "Infrastructure numérique",
     secteur: "infrastructureNumerique",
   },
   {
     libelleActivite:
-      "Fournisseurs de services de communications électroniques accessibles au public",
+      "Fournisseur de services de communications électroniques accessibles au public",
     activite: "fournisseurServiceCommunicationElectroniquesPublics",
     libelleSecteur: "Infrastructure numérique",
     secteur: "infrastructureNumerique",
   },
   {
     libelleActivite:
-      "Fournisseurs de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines",
+      "Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines",
     activite: "fournisseurServicesDNS",
     libelleSecteur: "Infrastructure numérique",
     secteur: "infrastructureNumerique",
   },
   {
-    libelleActivite: "Registres de noms de domaines de premier niveau",
+    libelleActivite: "Registre de noms de domaines de premier niveau",
     activite: "registresNomsDomainesPremierNiveau",
     libelleSecteur: "Infrastructure numérique",
     secteur: "infrastructureNumerique",
@@ -47,31 +47,31 @@ export const infrastructureNumerique: CasDeTest[] = [
     secteur: "infrastructureNumerique",
   },
   {
-    libelleActivite: "Prestataires de service de confiance qualifié",
+    libelleActivite: "Prestataire de service de confiance qualifié",
     activite: "prestataireServiceConfianceQualifie",
     libelleSecteur: "Infrastructure numérique",
     secteur: "infrastructureNumerique",
   },
   {
-    libelleActivite: "Prestataires de service de confiance non qualifié",
+    libelleActivite: "Prestataire de service de confiance non qualifié",
     activite: "prestataireServiceConfianceNonQualifie",
     libelleSecteur: "Infrastructure numérique",
     secteur: "infrastructureNumerique",
   },
   {
-    libelleActivite: "Fournisseurs de services d'informatique en nuage",
+    libelleActivite: "Fournisseur de services d'informatique en nuage",
     activite: "fournisseurServicesInformatiqueNuage",
     libelleSecteur: "Infrastructure numérique",
     secteur: "infrastructureNumerique",
   },
   {
-    libelleActivite: "Fournisseurs de services de centres de données",
+    libelleActivite: "Fournisseur de services de centres de données",
     activite: "fournisseurServiceCentresDonnees",
     libelleSecteur: "Infrastructure numérique",
     secteur: "infrastructureNumerique",
   },
   {
-    libelleActivite: "Fournisseurs de réseaux de diffusion de contenu",
+    libelleActivite: "Fournisseur de réseaux de diffusion de contenu",
     activite: "fournisseurReseauxDiffusionContenu",
     libelleSecteur: "Infrastructure numérique",
     secteur: "infrastructureNumerique",
@@ -86,13 +86,13 @@ export const infrastructureNumerique: CasDeTest[] = [
 
 export const gestionDesServicesTIC: CasDeTest[] = [
   {
-    libelleActivite: "Fournisseurs de services gérés",
+    libelleActivite: "Fournisseur de services gérés",
     activite: "fournisseurServicesGeres",
     libelleSecteur: "Gestion des services TIC",
     secteur: "gestionServicesTic",
   },
   {
-    libelleActivite: "Fournisseurs de services de sécurité gérés",
+    libelleActivite: "Fournisseur de services de sécurité gérés",
     activite: "fournisseurServicesSecuriteGeres",
     libelleSecteur: "Gestion des services TIC",
     secteur: "gestionServicesTic",
@@ -107,20 +107,20 @@ export const gestionDesServicesTIC: CasDeTest[] = [
 
 export const fournisseursNumeriques: CasDeTest[] = [
   {
-    libelleActivite: "Fournisseurs de places de marché en ligne",
+    libelleActivite: "Fournisseur de places de marché en ligne",
     activite: "fournisseursPlaceMarcheEnLigne",
     libelleSecteur: "Fournisseurs numériques",
     secteur: "fournisseursNumeriques",
   },
   {
-    libelleActivite: "Fournisseurs de moteurs de recherche en ligne",
+    libelleActivite: "Fournisseur de moteurs de recherche en ligne",
     activite: "fournisseursMoteursRechercheEnLigne",
     libelleSecteur: "Fournisseurs numériques",
     secteur: "fournisseursNumeriques",
   },
   {
     libelleActivite:
-      "Fournisseurs de plateformes de services de réseaux sociaux",
+      "Fournisseur de plateformes de services de réseaux sociaux",
     activite: "fournisseursPlateformesServicesReseauxSociaux",
     libelleSecteur: "Fournisseurs numériques",
     secteur: "fournisseursNumeriques",

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
@@ -1,2 +1,2 @@
 Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Resultat
-Oui;;;;;;;;Regule EE
+Oui;-;-;-;-;-;-;-;Régulée EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
@@ -1,2 +1,2 @@
 Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Resultat
-Oui;France;;;;;;;Regule EE
+Oui;France;-;-;-;-;-;-;Régulée EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specs-completes-de-travail.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specs-completes-de-travail.csv
@@ -1,0 +1,285 @@
+﻿Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Extra - Établissement principal;Resultat;Points d'attention;Code
+Oui;-;-;-;-;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1000
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1001
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1002
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États hors Union Européenne;-;Non régulée;-;R1003
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne;-;Régulée EI;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1004
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États hors Union Européenne;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1005
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1006
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EI;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1007
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1008
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1009
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États hors Union Européenne;-;Non régulée;-;R1010
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne;-;Régulée EI;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1011
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États hors Union Européenne;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1012
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1013
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EI;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1014
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1015
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1016
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1017
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1018
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;France;Régulée, enregistrement seul;#MecanismeExemption, #EnregistrementNomsDeDomaines, #ResilienceEntiteCritique, #SecuriteNationale;R1019
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1020
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Prestataire de service de confiance qualifié;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1021
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Prestataire de service de confiance non qualifié;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1022
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1023
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de centres de données;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1024
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1025
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de points d'échange internet;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1026
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1027
+Non;France;Entreprise privée ou publique;Petite;Banques (secteur bancaire);-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1028
+Non;France;Entreprise privée ou publique;Petite;Banques (secteur bancaire);-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1029
+Non;France;Entreprise privée ou publique;Petite;Eau potable;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1030
+Non;France;Entreprise privée ou publique;Petite;Eau potable;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1031
+Non;France;Entreprise privée ou publique;Petite;Eaux usées;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1032
+Non;France;Entreprise privée ou publique;Petite;Eaux usées;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1033
+Non;France;Entreprise privée ou publique;Petite;Énergie;Électricité;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1034
+Non;France;Entreprise privée ou publique;Petite;Énergie;Électricité;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1035
+Non;France;Entreprise privée ou publique;Petite;Énergie;Gaz;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1036
+Non;France;Entreprise privée ou publique;Petite;Énergie;Gaz;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1037
+Non;France;Entreprise privée ou publique;Petite;Énergie;Hydrogène;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1038
+Non;France;Entreprise privée ou publique;Petite;Énergie;Hydrogène;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1039
+Non;France;Entreprise privée ou publique;Petite;Énergie;Pétrole;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1040
+Non;France;Entreprise privée ou publique;Petite;Énergie;Pétrole;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1041
+Non;France;Entreprise privée ou publique;Petite;Énergie;Réseaux de chaleur et de froid;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1042
+Non;France;Entreprise privée ou publique;Petite;Énergie;Réseaux de chaleur et de froid;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1043
+Non;France;Entreprise privée ou publique;Petite;Énergie;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1044
+Non;France;Entreprise privée ou publique;Petite;Espace;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1045
+Non;France;Entreprise privée ou publique;Petite;Espace;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1046
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1047
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1048
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication d'équipements électriques;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1049
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication d'équipements électriques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1050
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de produits informatiques, électroniques et optiques;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1051
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de produits informatiques, électroniques et optiques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1052
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de machines et équipements n.c.a.;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1053
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de machines et équipements n.c.a.;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1054
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1055
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1056
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication d'autres matériels de transport;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1057
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication d'autres matériels de transport;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1058
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1059
+Non;France;Entreprise privée ou publique;Petite;Fabrication, production et distribution de produits chimiques;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1060
+Non;France;Entreprise privée ou publique;Petite;Fabrication, production et distribution de produits chimiques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1061
+Non;France;Entreprise privée ou publique;Petite;Fournisseurs numériques;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1062
+Non;France;Entreprise privée ou publique;Petite;Fournisseurs numériques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1063
+Non;France;Entreprise privée ou publique;Petite;Gestion des déchets;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1064
+Non;France;Entreprise privée ou publique;Petite;Gestion des déchets;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1065
+Non;France;Entreprise privée ou publique;Petite;Gestion des services TIC;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1066
+Non;France;Entreprise privée ou publique;Petite;Gestion des services TIC;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1067
+Non;France;Entreprise privée ou publique;Petite;Infrastructure des marchés financiers;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1068
+Non;France;Entreprise privée ou publique;Petite;Infrastructure des marchés financiers;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1069
+Non;France;Entreprise privée ou publique;Petite;Production transformation et distribution de denrées alimentaires;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1070
+Non;France;Entreprise privée ou publique;Petite;Production transformation et distribution de denrées alimentaires;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1071
+Non;France;Entreprise privée ou publique;Petite;Recherche;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1072
+Non;France;Entreprise privée ou publique;Petite;Recherche;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1073
+Non;France;Entreprise privée ou publique;Petite;Santé;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1074
+Non;France;Entreprise privée ou publique;Petite;Santé;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1075
+Non;France;Entreprise privée ou publique;Petite;Services postaux et d'expédition;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1076
+Non;France;Entreprise privée ou publique;Petite;Services postaux et d'expédition;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1077
+Non;France;Entreprise privée ou publique;Petite;Transports;Aériens;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1078
+Non;France;Entreprise privée ou publique;Petite;Transports;Aériens;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1079
+Non;France;Entreprise privée ou publique;Petite;Transports;Ferroviaires;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1080
+Non;France;Entreprise privée ou publique;Petite;Transports;Ferroviaires;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1081
+Non;France;Entreprise privée ou publique;Petite;Transports;Par eau;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1082
+Non;France;Entreprise privée ou publique;Petite;Transports;Par eau;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1083
+Non;France;Entreprise privée ou publique;Petite;Transports;Routiers;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1084
+Non;France;Entreprise privée ou publique;Petite;Transports;Routiers;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1085
+Non;France;Entreprise privée ou publique;Petite;Transports;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1086
+Non;France;Entreprise privée ou publique;Petite;Autre secteur d'activité;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1087
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1088
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1089
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États hors Union Européenne;-;Non régulée;-;R1090
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1091
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États hors Union Européenne;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1092
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1093
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1094
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1095
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1096
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États hors Union Européenne;-;Non régulée;-;R1097
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1098
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États hors Union Européenne;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1099
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1100
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1101
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1102
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1103
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1104
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1105
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1106
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1107
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de centres de données;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1108
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de centres de données;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1109
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1110
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1111
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;France;Régulée, enregistrement seul;#MecanismeExemption, #EnregistrementNomsDeDomaines, #ResilienceEntiteCritique, #SecuriteNationale;R1112
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1113
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Prestataire de service de confiance qualifié;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1114
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Prestataire de service de confiance non qualifié;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1115
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de points d'échange internet;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1116
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1117
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Fournisseur de services gérés;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1118
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Fournisseur de services gérés;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1119
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Fournisseur de services de sécurité gérés;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1120
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Fournisseur de services de sécurité gérés;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1121
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1122
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de places de marché en ligne;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1123
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de places de marché en ligne;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1124
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de moteurs de recherche en ligne;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1125
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de moteurs de recherche en ligne;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1126
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de plateformes de services de réseaux sociaux;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1127
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de plateformes de services de réseaux sociaux;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1128
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1129
+Non;France;Entreprise privée ou publique;Moyenne;Banques (secteur bancaire);-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1130
+Non;France;Entreprise privée ou publique;Moyenne;Banques (secteur bancaire);-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1131
+Non;France;Entreprise privée ou publique;Moyenne;Eau potable;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1132
+Non;France;Entreprise privée ou publique;Moyenne;Eau potable;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1133
+Non;France;Entreprise privée ou publique;Moyenne;Eaux usées;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1134
+Non;France;Entreprise privée ou publique;Moyenne;Eaux usées;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1135
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Électricité;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1136
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Électricité;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1137
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Gaz;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1138
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Gaz;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1139
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Hydrogène;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1140
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Hydrogène;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1141
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Pétrole;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1142
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Pétrole;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1143
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Réseaux de chaleur et de froid;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1144
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Réseaux de chaleur et de froid;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1145
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1146
+Non;France;Entreprise privée ou publique;Moyenne;Espace;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1147
+Non;France;Entreprise privée ou publique;Moyenne;Espace;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1148
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1149
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1150
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication d'équipements électriques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1151
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication d'équipements électriques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1152
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de produits informatiques, électroniques et optiques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1153
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de produits informatiques, électroniques et optiques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1154
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de machines et équipements n.c.a.;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1155
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de machines et équipements n.c.a.;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1156
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1157
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1158
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication d'autres matériels de transport;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1159
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication d'autres matériels de transport;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1160
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Autre sous-secteur;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1161
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication, production et distribution de produits chimiques;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1162
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication, production et distribution de produits chimiques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1163
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des déchets;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1164
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des déchets;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1165
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure des marchés financiers;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1166
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure des marchés financiers;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1167
+Non;France;Entreprise privée ou publique;Moyenne;Production transformation et distribution de denrées alimentaires;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1168
+Non;France;Entreprise privée ou publique;Moyenne;Production transformation et distribution de denrées alimentaires;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1169
+Non;France;Entreprise privée ou publique;Moyenne;Recherche;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1170
+Non;France;Entreprise privée ou publique;Moyenne;Recherche;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1171
+Non;France;Entreprise privée ou publique;Moyenne;Santé;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1172
+Non;France;Entreprise privée ou publique;Moyenne;Santé;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1173
+Non;France;Entreprise privée ou publique;Moyenne;Services postaux et d'expédition;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1174
+Non;France;Entreprise privée ou publique;Moyenne;Services postaux et d'expédition;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1175
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Aériens;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1176
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Aériens;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1177
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Ferroviaires;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1178
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Ferroviaires;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1179
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Par eau;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1180
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Par eau;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1181
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Routiers;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1182
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Routiers;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1183
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1184
+Non;France;Entreprise privée ou publique;Moyenne;Autre secteur d'activité;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1185
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1186
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1187
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États hors Union Européenne;-;Non régulée;-;R1188
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1189
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États hors Union Européenne;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1190
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1191
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1192
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1193
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1194
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États hors Union Européenne;-;Non régulée;-;R1195
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1196
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États hors Union Européenne;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1197
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1198
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1199
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1200
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1201
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1202
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1203
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1204
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1205
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de centres de données;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1206
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de centres de données;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1207
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1208
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1209
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;France;Régulée, enregistrement seul;#MecanismeExemption, #EnregistrementNomsDeDomaines, #ResilienceEntiteCritique, #SecuriteNationale;R1210
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1211
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Prestataire de service de confiance qualifié;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1212
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Prestataire de service de confiance non qualifié;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1213
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de points d'échange internet;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1214
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1215
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Fournisseur de services gérés;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1216
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Fournisseur de services gérés;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1217
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Fournisseur de services de sécurité gérés;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1218
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Fournisseur de services de sécurité gérés;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1219
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1220
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de places de marché en ligne;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1221
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de places de marché en ligne;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1222
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de moteurs de recherche en ligne;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1223
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de moteurs de recherche en ligne;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1224
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de plateformes de services de réseaux sociaux;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1225
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de plateformes de services de réseaux sociaux;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1226
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1227
+Non;France;Entreprise privée ou publique;Grande;Banques (secteur bancaire);-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1228
+Non;France;Entreprise privée ou publique;Grande;Banques (secteur bancaire);-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1229
+Non;France;Entreprise privée ou publique;Grande;Eau potable;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1230
+Non;France;Entreprise privée ou publique;Grande;Eau potable;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1231
+Non;France;Entreprise privée ou publique;Grande;Eaux usées;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1232
+Non;France;Entreprise privée ou publique;Grande;Eaux usées;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1233
+Non;France;Entreprise privée ou publique;Grande;Énergie;Électricité;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1234
+Non;France;Entreprise privée ou publique;Grande;Énergie;Électricité;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1235
+Non;France;Entreprise privée ou publique;Grande;Énergie;Gaz;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1236
+Non;France;Entreprise privée ou publique;Grande;Énergie;Gaz;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1237
+Non;France;Entreprise privée ou publique;Grande;Énergie;Hydrogène;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1238
+Non;France;Entreprise privée ou publique;Grande;Énergie;Hydrogène;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1239
+Non;France;Entreprise privée ou publique;Grande;Énergie;Pétrole;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1240
+Non;France;Entreprise privée ou publique;Grande;Énergie;Pétrole;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1241
+Non;France;Entreprise privée ou publique;Grande;Énergie;Réseaux de chaleur et de froid;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1242
+Non;France;Entreprise privée ou publique;Grande;Énergie;Réseaux de chaleur et de froid;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1243
+Non;France;Entreprise privée ou publique;Grande;Énergie;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1244
+Non;France;Entreprise privée ou publique;Grande;Espace;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1245
+Non;France;Entreprise privée ou publique;Grande;Espace;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1246
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1247
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1248
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication d'équipements électriques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1249
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication d'équipements électriques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1250
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de produits informatiques, électroniques et optiques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1251
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de produits informatiques, électroniques et optiques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1252
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de machines et équipements n.c.a.;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1253
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de machines et équipements n.c.a.;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1254
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1255
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1256
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication d'autres matériels de transport;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1257
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication d'autres matériels de transport;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1258
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Autre sous-secteur;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1259
+Non;France;Entreprise privée ou publique;Grande;Fabrication, production et distribution de produits chimiques;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1260
+Non;France;Entreprise privée ou publique;Grande;Fabrication, production et distribution de produits chimiques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1261
+Non;France;Entreprise privée ou publique;Grande;Gestion des déchets;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1262
+Non;France;Entreprise privée ou publique;Grande;Gestion des déchets;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1263
+Non;France;Entreprise privée ou publique;Grande;Infrastructure des marchés financiers;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1264
+Non;France;Entreprise privée ou publique;Grande;Infrastructure des marchés financiers;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1265
+Non;France;Entreprise privée ou publique;Grande;Production transformation et distribution de denrées alimentaires;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1266
+Non;France;Entreprise privée ou publique;Grande;Production transformation et distribution de denrées alimentaires;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1267
+Non;France;Entreprise privée ou publique;Grande;Recherche;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1268
+Non;France;Entreprise privée ou publique;Grande;Recherche;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1269
+Non;France;Entreprise privée ou publique;Grande;Santé;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1270
+Non;France;Entreprise privée ou publique;Grande;Santé;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1271
+Non;France;Entreprise privée ou publique;Grande;Services postaux et d'expédition;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1272
+Non;France;Entreprise privée ou publique;Grande;Services postaux et d'expédition;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1273
+Non;France;Entreprise privée ou publique;Grande;Transports;Aériens;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1274
+Non;France;Entreprise privée ou publique;Grande;Transports;Aériens;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1275
+Non;France;Entreprise privée ou publique;Grande;Transports;Ferroviaires;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1276
+Non;France;Entreprise privée ou publique;Grande;Transports;Ferroviaires;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1277
+Non;France;Entreprise privée ou publique;Grande;Transports;Par eau;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1278
+Non;France;Entreprise privée ou publique;Grande;Transports;Par eau;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1279
+Non;France;Entreprise privée ou publique;Grande;Transports;Routiers;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1280
+Non;France;Entreprise privée ou publique;Grande;Transports;Routiers;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1281
+Non;France;Entreprise privée ou publique;Grande;Transports;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1282
+Non;France;Entreprise privée ou publique;Grande;Autre secteur d'activité;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1283


### PR DESCRIPTION
Cette PR ajoute un CSV de PROD, et la lecture de celui-ci dans un test automatisé.

Cela permet de détecter les ajustements à faire.

Entre autres :
 - la valeur vide devient le tiret du 6
 - certains accents sont rajoutés (comme sur « entreprise privée »)
 - certaines Activités sont rajoutées dans `RegleActivite`
 - les noms d'activités passent au singulier
 - des apostrophes sont remises au propre (' au lieu de ’)
