### PR TITLE
Comparaison entre réponse v1 et v2

### DIFF
--- a/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/AiguilleVersEtapeResultat.tsx
@@ -5,6 +5,7 @@ import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulate
 import { ReactElement } from "react";
 import { evalueEligibilite } from "../../questionnaire/specifications/EvalueEligibilite.ts";
 import SpecificationsCompletes from "../../questionnaire/specifications/specifications-completes.csv?raw";
+import { compareEtEnvoieVersSentry } from "./compareEtEnvoieVersSentry.tsx";
 
 export function AiguilleVersEtapeResultat(props: {
   version: string;
@@ -14,19 +15,27 @@ export function AiguilleVersEtapeResultat(props: {
   const afficheV2 = props.version === "v2";
   const afficheLesDeux = props.version === "all";
 
+  const v1: ReactElement = (
+    <EtapeResultat
+      reponses={props.reponses}
+      comparateurV1V2={compareEtEnvoieVersSentry}
+    />
+  );
+
   const v2: ReactElement = (
     <AvecEvaluationEligibilitie reponses={props.reponses}>
       {(r: ResultatEligibilite) => <EtapeResultatV2 resultat={r} />}
     </AvecEvaluationEligibilitie>
   );
 
-  if (afficheV1) return <EtapeResultat reponses={props.reponses} />;
+  if (afficheV1) return v1;
+
   if (afficheV2) return v2;
 
   if (afficheLesDeux)
     return (
       <>
-        <EtapeResultat reponses={props.reponses} />
+        v1
         <hr />
         {v2}
       </>

--- a/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeResultat.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/EtapesRefacto/EtapeResultat.tsx
@@ -1,7 +1,10 @@
 import { LigneResultat } from "../Resultats/LigneResultat.tsx";
 import { DonneesFormulaireSimulateur } from "anssi-nis2-core/src/Domain/Simulateur/services/DonneesFormulaire/DonneesFormulaire.definitions.ts";
 import { ConvertisseurDonneesBrutesVersEtatDonneesSimulateur } from "anssi-nis2-core/src/Domain/Simulateur/services/Eligibilite/ReponseEtat.fabriques.ts";
-import { EtatRegulation } from "anssi-nis2-core/src/Domain/Simulateur/services/Eligibilite/EtatRegulation.definitions.ts";
+import {
+  EtatRegulation,
+  EtatRegulationDefinitif,
+} from "anssi-nis2-core/src/Domain/Simulateur/services/Eligibilite/EtatRegulation.definitions.ts";
 import { evalueEtatRegulation } from "anssi-nis2-core/src/Domain/Simulateur/services/Eligibilite/EvalueEtatRegulation.ts";
 import { LigneResterInformer } from "../Resultats/LigneResterInformer.tsx";
 import {
@@ -13,17 +16,28 @@ import { LigneEtMaintenant } from "../Resultats/LigneEtMaintenant.tsx";
 import { EnSavoirPlus } from "../Resultats/EnSavoirPlus.tsx";
 import { LigneBienDebuter } from "../Resultats/LigneBienDebuter.tsx";
 import { LigneReseauxSociaux } from "../Resultats/LigneReseauxSociaux.tsx";
+import { useEffect } from "react";
 
 export const EtapeResultat = ({
   reponses,
+  comparateurV1V2,
 }: {
   reponses: DonneesFormulaireSimulateur;
+  comparateurV1V2: (
+    reponses: DonneesFormulaireSimulateur,
+    regulationV1: EtatRegulationDefinitif,
+  ) => void;
 }) => {
   const donneesReponse =
     ConvertisseurDonneesBrutesVersEtatDonneesSimulateur.depuisDonneesFormulaireSimulateur(
       reponses,
     ) as EtatRegulation;
   const etatRegulation = evalueEtatRegulation(donneesReponse);
+
+  useEffect(() => {
+    comparateurV1V2(reponses, etatRegulation);
+  }, [reponses, comparateurV1V2, etatRegulation]);
+
   const modeFormulaireEmail = getModeFormulaireEmail(etatRegulation.decision);
 
   return (

--- a/anssi-nis2-ui/src/Components/Simulateur/compareEtEnvoieVersSentry.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/compareEtEnvoieVersSentry.tsx
@@ -14,8 +14,16 @@ export function compareEtEnvoieVersSentry(
       SpecificationsCompletes,
     );
 
+    const estIdentique =
+      resultatV2.regulation === regulationV1.decision &&
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      resultatV2.typeEntite === regulationV1?.typeEntite;
+
+    const niveauLog = estIdentique ? "info" : "error";
+
     Sentry.captureMessage("COMPARAISON V1 & V2", {
-      level: "info",
+      level: niveauLog,
       extra: { reponses, resultatV2, regulationV1 },
     });
   } catch (e) {

--- a/anssi-nis2-ui/src/Components/Simulateur/compareEtEnvoieVersSentry.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/compareEtEnvoieVersSentry.tsx
@@ -1,0 +1,24 @@
+import * as Sentry from "@sentry/react";
+import { DonneesFormulaireSimulateur } from "../../../../commun/core/src/Domain/Simulateur/services/DonneesFormulaire/DonneesFormulaire.definitions.ts";
+import { EtatRegulationDefinitif } from "../../../../commun/core/src/Domain/Simulateur/services/Eligibilite/EtatRegulation.definitions.ts";
+import { evalueEligibilite } from "../../questionnaire/specifications/EvalueEligibilite.ts";
+import SpecificationsCompletes from "../../questionnaire/specifications/specifications-completes.csv?raw";
+
+export function compareEtEnvoieVersSentry(
+  reponses: DonneesFormulaireSimulateur,
+  regulationV1: EtatRegulationDefinitif,
+): void {
+  try {
+    const resultatV2 = evalueEligibilite(
+      { ...reponses, etapeCourante: "resultat" },
+      SpecificationsCompletes,
+    );
+
+    Sentry.captureMessage("COMPARAISON V1 & V2", {
+      level: "info",
+      extra: { reponses, resultatV2, regulationV1 },
+    });
+  } catch (e) {
+    Sentry.captureException(e, { extra: { reponses, regulationV1 } });
+  }
+}

--- a/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/EtapeResultat.stories.tsx
+++ b/anssi-nis2-ui/src/stories/Components/Simulateur/EtapesRefacto/EtapeResultat.stories.tsx
@@ -11,6 +11,7 @@ import {
 import { attendTexteCharge } from "../../../utilitaires/interaction.facilitateurs.ts";
 import { verifieTitresSectionsPresentes } from "../Resultat/Resultat.aide.ts";
 import { EtapeResultat } from "../../../../Components/Simulateur/EtapesRefacto/EtapeResultat.tsx";
+import { compareEtEnvoieVersSentry } from "../../../../Components/Simulateur/compareEtEnvoieVersSentry.tsx";
 
 const archetypeDonneesFormulaire = fabriqueDonneesFormulaire({
   designationOperateurServicesEssentiels: ["non"],
@@ -26,7 +27,10 @@ const archetypeDonneesFormulaire = fabriqueDonneesFormulaire({
 const meta: Meta<typeof EtapeResultat> = {
   title: "Composants/Simulateur/Resultat",
   component: EtapeResultat,
-  args: { reponses: archetypeDonneesFormulaire },
+  args: {
+    reponses: archetypeDonneesFormulaire,
+    comparateurV1V2: compareEtEnvoieVersSentry,
+  },
 };
 
 export default meta;


### PR DESCRIPTION
Cette PR compare les réponses `v1` avec les réponses `v2` :

 - L'utilisateur répond en `v1`
 - Au moment de l'enregistrement du résultat `v1`, les réponses sont soumises en coulisse à l'algo `v2`
 - Les 3 éléments (réponses, résultat `v1`, résultat `v2`) sont envoyés vers Sentry, pour comparaison
 - Si l'éligibilité est la même, le log Sentry se fait en `info` sinon il se fait en `error`


Le but est de monitorer Sentry sur plusieurs jours pour vérifier le comportement de l'algo `v2` par rapport au `v1`.