### PR TITLE
Utilise les specs CSV de travail pour la PROD

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
+++ b/anssi-nis2-ui/src/questionnaire/specifications/specifications-completes.csv
@@ -1,2 +1,285 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Resultat
-Oui;-;-;-;-;-;-;-;Régulée EE
+﻿Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Extra - Établissement principal;Resultat;Points d'attention;Code
+Oui;-;-;-;-;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1000
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1001
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1002
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États hors Union Européenne;-;Non régulée;-;R1003
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne;-;Régulée EI;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1004
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États hors Union Européenne;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1005
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1006
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EI;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1007
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1008
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1009
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États hors Union Européenne;-;Non régulée;-;R1010
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne;-;Régulée EI;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1011
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États hors Union Européenne;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1012
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1013
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EI;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1014
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1015
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1016
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1017
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1018
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;France;Régulée, enregistrement seul;#MecanismeExemption, #EnregistrementNomsDeDomaines, #ResilienceEntiteCritique, #SecuriteNationale;R1019
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1020
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Prestataire de service de confiance qualifié;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1021
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Prestataire de service de confiance non qualifié;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1022
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1023
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de services de centres de données;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1024
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1025
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Fournisseur de points d'échange internet;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1026
+Non;France;Entreprise privée ou publique;Petite;Infrastructure numérique;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1027
+Non;France;Entreprise privée ou publique;Petite;Banques (secteur bancaire);-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1028
+Non;France;Entreprise privée ou publique;Petite;Banques (secteur bancaire);-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1029
+Non;France;Entreprise privée ou publique;Petite;Eau potable;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1030
+Non;France;Entreprise privée ou publique;Petite;Eau potable;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1031
+Non;France;Entreprise privée ou publique;Petite;Eaux usées;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1032
+Non;France;Entreprise privée ou publique;Petite;Eaux usées;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1033
+Non;France;Entreprise privée ou publique;Petite;Énergie;Électricité;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1034
+Non;France;Entreprise privée ou publique;Petite;Énergie;Électricité;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1035
+Non;France;Entreprise privée ou publique;Petite;Énergie;Gaz;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1036
+Non;France;Entreprise privée ou publique;Petite;Énergie;Gaz;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1037
+Non;France;Entreprise privée ou publique;Petite;Énergie;Hydrogène;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1038
+Non;France;Entreprise privée ou publique;Petite;Énergie;Hydrogène;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1039
+Non;France;Entreprise privée ou publique;Petite;Énergie;Pétrole;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1040
+Non;France;Entreprise privée ou publique;Petite;Énergie;Pétrole;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1041
+Non;France;Entreprise privée ou publique;Petite;Énergie;Réseaux de chaleur et de froid;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1042
+Non;France;Entreprise privée ou publique;Petite;Énergie;Réseaux de chaleur et de froid;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1043
+Non;France;Entreprise privée ou publique;Petite;Énergie;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1044
+Non;France;Entreprise privée ou publique;Petite;Espace;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1045
+Non;France;Entreprise privée ou publique;Petite;Espace;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1046
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1047
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1048
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication d'équipements électriques;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1049
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication d'équipements électriques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1050
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de produits informatiques, électroniques et optiques;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1051
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de produits informatiques, électroniques et optiques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1052
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de machines et équipements n.c.a.;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1053
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication de machines et équipements n.c.a.;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1054
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1055
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1056
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication d'autres matériels de transport;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1057
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Fabrication d'autres matériels de transport;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1058
+Non;France;Entreprise privée ou publique;Petite;Fabrication;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1059
+Non;France;Entreprise privée ou publique;Petite;Fabrication, production et distribution de produits chimiques;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1060
+Non;France;Entreprise privée ou publique;Petite;Fabrication, production et distribution de produits chimiques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1061
+Non;France;Entreprise privée ou publique;Petite;Fournisseurs numériques;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1062
+Non;France;Entreprise privée ou publique;Petite;Fournisseurs numériques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1063
+Non;France;Entreprise privée ou publique;Petite;Gestion des déchets;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1064
+Non;France;Entreprise privée ou publique;Petite;Gestion des déchets;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1065
+Non;France;Entreprise privée ou publique;Petite;Gestion des services TIC;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1066
+Non;France;Entreprise privée ou publique;Petite;Gestion des services TIC;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1067
+Non;France;Entreprise privée ou publique;Petite;Infrastructure des marchés financiers;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1068
+Non;France;Entreprise privée ou publique;Petite;Infrastructure des marchés financiers;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1069
+Non;France;Entreprise privée ou publique;Petite;Production transformation et distribution de denrées alimentaires;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1070
+Non;France;Entreprise privée ou publique;Petite;Production transformation et distribution de denrées alimentaires;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1071
+Non;France;Entreprise privée ou publique;Petite;Recherche;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1072
+Non;France;Entreprise privée ou publique;Petite;Recherche;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1073
+Non;France;Entreprise privée ou publique;Petite;Santé;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1074
+Non;France;Entreprise privée ou publique;Petite;Santé;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1075
+Non;France;Entreprise privée ou publique;Petite;Services postaux et d'expédition;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1076
+Non;France;Entreprise privée ou publique;Petite;Services postaux et d'expédition;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1077
+Non;France;Entreprise privée ou publique;Petite;Transports;Aériens;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1078
+Non;France;Entreprise privée ou publique;Petite;Transports;Aériens;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1079
+Non;France;Entreprise privée ou publique;Petite;Transports;Ferroviaires;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1080
+Non;France;Entreprise privée ou publique;Petite;Transports;Ferroviaires;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1081
+Non;France;Entreprise privée ou publique;Petite;Transports;Par eau;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1082
+Non;France;Entreprise privée ou publique;Petite;Transports;Par eau;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1083
+Non;France;Entreprise privée ou publique;Petite;Transports;Routiers;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1084
+Non;France;Entreprise privée ou publique;Petite;Transports;Routiers;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1085
+Non;France;Entreprise privée ou publique;Petite;Transports;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1086
+Non;France;Entreprise privée ou publique;Petite;Autre secteur d'activité;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1087
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1088
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1089
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États hors Union Européenne;-;Non régulée;-;R1090
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1091
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États hors Union Européenne;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1092
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1093
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1094
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1095
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1096
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États hors Union Européenne;-;Non régulée;-;R1097
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1098
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États hors Union Européenne;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1099
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1100
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1101
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1102
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1103
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1104
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1105
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1106
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1107
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de centres de données;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1108
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de services de centres de données;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1109
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1110
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1111
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;France;Régulée, enregistrement seul;#MecanismeExemption, #EnregistrementNomsDeDomaines, #ResilienceEntiteCritique, #SecuriteNationale;R1112
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1113
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Prestataire de service de confiance qualifié;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1114
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Prestataire de service de confiance non qualifié;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1115
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Fournisseur de points d'échange internet;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1116
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure numérique;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1117
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Fournisseur de services gérés;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1118
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Fournisseur de services gérés;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1119
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Fournisseur de services de sécurité gérés;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1120
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Fournisseur de services de sécurité gérés;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1121
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des services TIC;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1122
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de places de marché en ligne;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1123
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de places de marché en ligne;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1124
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de moteurs de recherche en ligne;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1125
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de moteurs de recherche en ligne;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1126
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de plateformes de services de réseaux sociaux;-;France;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1127
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Fournisseur de plateformes de services de réseaux sociaux;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1128
+Non;France;Entreprise privée ou publique;Moyenne;Fournisseurs numériques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1129
+Non;France;Entreprise privée ou publique;Moyenne;Banques (secteur bancaire);-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1130
+Non;France;Entreprise privée ou publique;Moyenne;Banques (secteur bancaire);-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1131
+Non;France;Entreprise privée ou publique;Moyenne;Eau potable;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1132
+Non;France;Entreprise privée ou publique;Moyenne;Eau potable;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1133
+Non;France;Entreprise privée ou publique;Moyenne;Eaux usées;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1134
+Non;France;Entreprise privée ou publique;Moyenne;Eaux usées;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1135
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Électricité;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1136
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Électricité;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1137
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Gaz;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1138
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Gaz;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1139
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Hydrogène;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1140
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Hydrogène;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1141
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Pétrole;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1142
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Pétrole;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1143
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Réseaux de chaleur et de froid;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1144
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Réseaux de chaleur et de froid;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1145
+Non;France;Entreprise privée ou publique;Moyenne;Énergie;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1146
+Non;France;Entreprise privée ou publique;Moyenne;Espace;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1147
+Non;France;Entreprise privée ou publique;Moyenne;Espace;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1148
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1149
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1150
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication d'équipements électriques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1151
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication d'équipements électriques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1152
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de produits informatiques, électroniques et optiques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1153
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de produits informatiques, électroniques et optiques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1154
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de machines et équipements n.c.a.;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1155
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication de machines et équipements n.c.a.;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1156
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1157
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1158
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication d'autres matériels de transport;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1159
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Fabrication d'autres matériels de transport;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1160
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication;Autre sous-secteur;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1161
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication, production et distribution de produits chimiques;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1162
+Non;France;Entreprise privée ou publique;Moyenne;Fabrication, production et distribution de produits chimiques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1163
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des déchets;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1164
+Non;France;Entreprise privée ou publique;Moyenne;Gestion des déchets;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1165
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure des marchés financiers;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1166
+Non;France;Entreprise privée ou publique;Moyenne;Infrastructure des marchés financiers;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1167
+Non;France;Entreprise privée ou publique;Moyenne;Production transformation et distribution de denrées alimentaires;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1168
+Non;France;Entreprise privée ou publique;Moyenne;Production transformation et distribution de denrées alimentaires;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1169
+Non;France;Entreprise privée ou publique;Moyenne;Recherche;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1170
+Non;France;Entreprise privée ou publique;Moyenne;Recherche;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1171
+Non;France;Entreprise privée ou publique;Moyenne;Santé;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1172
+Non;France;Entreprise privée ou publique;Moyenne;Santé;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1173
+Non;France;Entreprise privée ou publique;Moyenne;Services postaux et d'expédition;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1174
+Non;France;Entreprise privée ou publique;Moyenne;Services postaux et d'expédition;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1175
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Aériens;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1176
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Aériens;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1177
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Ferroviaires;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1178
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Ferroviaires;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1179
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Par eau;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1180
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Par eau;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1181
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Routiers;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1182
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Routiers;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1183
+Non;France;Entreprise privée ou publique;Moyenne;Transports;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1184
+Non;France;Entreprise privée ou publique;Moyenne;Autre secteur d'activité;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1185
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1186
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1187
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États hors Union Européenne;-;Non régulée;-;R1188
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1189
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États hors Union Européenne;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1190
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1191
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de communications électroniques publics;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1192
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1193
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1194
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États hors Union Européenne;-;Non régulée;-;R1195
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1196
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États hors Union Européenne;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1197
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée, sans précision EE/EI;#FournitureServicesUE;R1198
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de communications électroniques accessibles au public;France + Autres États membres de l'Union Européenne + Autres États hors Union Européenne;-;Régulée EE;#TelecomUE, #MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1199
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1200
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services DNS, à l'exclusion des opérateurs de serveurs racines de noms de domaines;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1201
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1202
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Registre de noms de domaines de premier niveau;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1203
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1204
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services d'informatique en nuage;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1205
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de centres de données;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1206
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de services de centres de données;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1207
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1208
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de réseaux de diffusion de contenu;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1209
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;France;Régulée, enregistrement seul;#MecanismeExemption, #EnregistrementNomsDeDomaines, #ResilienceEntiteCritique, #SecuriteNationale;R1210
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur des services d'enregistrement de noms de domaine;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1211
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Prestataire de service de confiance qualifié;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1212
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Prestataire de service de confiance non qualifié;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1213
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Fournisseur de points d'échange internet;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1214
+Non;France;Entreprise privée ou publique;Grande;Infrastructure numérique;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1215
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Fournisseur de services gérés;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1216
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Fournisseur de services gérés;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1217
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Fournisseur de services de sécurité gérés;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1218
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Fournisseur de services de sécurité gérés;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1219
+Non;France;Entreprise privée ou publique;Grande;Gestion des services TIC;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1220
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de places de marché en ligne;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1221
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de places de marché en ligne;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1222
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de moteurs de recherche en ligne;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1223
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de moteurs de recherche en ligne;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1224
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de plateformes de services de réseaux sociaux;-;France;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1225
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Fournisseur de plateformes de services de réseaux sociaux;-;Autres États membres de l'Union Européenne;Régulée, sans précision EE/EI;#EtablissementPrincipalUE;R1226
+Non;France;Entreprise privée ou publique;Grande;Fournisseurs numériques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1227
+Non;France;Entreprise privée ou publique;Grande;Banques (secteur bancaire);-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1228
+Non;France;Entreprise privée ou publique;Grande;Banques (secteur bancaire);-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1229
+Non;France;Entreprise privée ou publique;Grande;Eau potable;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1230
+Non;France;Entreprise privée ou publique;Grande;Eau potable;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1231
+Non;France;Entreprise privée ou publique;Grande;Eaux usées;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1232
+Non;France;Entreprise privée ou publique;Grande;Eaux usées;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1233
+Non;France;Entreprise privée ou publique;Grande;Énergie;Électricité;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1234
+Non;France;Entreprise privée ou publique;Grande;Énergie;Électricité;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1235
+Non;France;Entreprise privée ou publique;Grande;Énergie;Gaz;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1236
+Non;France;Entreprise privée ou publique;Grande;Énergie;Gaz;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1237
+Non;France;Entreprise privée ou publique;Grande;Énergie;Hydrogène;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1238
+Non;France;Entreprise privée ou publique;Grande;Énergie;Hydrogène;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1239
+Non;France;Entreprise privée ou publique;Grande;Énergie;Pétrole;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1240
+Non;France;Entreprise privée ou publique;Grande;Énergie;Pétrole;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1241
+Non;France;Entreprise privée ou publique;Grande;Énergie;Réseaux de chaleur et de froid;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1242
+Non;France;Entreprise privée ou publique;Grande;Énergie;Réseaux de chaleur et de froid;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1243
+Non;France;Entreprise privée ou publique;Grande;Énergie;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1244
+Non;France;Entreprise privée ou publique;Grande;Espace;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1245
+Non;France;Entreprise privée ou publique;Grande;Espace;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1246
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1247
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de dispositifs médicaux et de dispositifs médicaux de diagnostic in vitro;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1248
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication d'équipements électriques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1249
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication d'équipements électriques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1250
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de produits informatiques, électroniques et optiques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1251
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de produits informatiques, électroniques et optiques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1252
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de machines et équipements n.c.a.;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1253
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication de machines et équipements n.c.a.;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1254
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1255
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Construction de véhicules automobiles, remorques et semi- remorques;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1256
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication d'autres matériels de transport;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1257
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Fabrication d'autres matériels de transport;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1258
+Non;France;Entreprise privée ou publique;Grande;Fabrication;Autre sous-secteur;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1259
+Non;France;Entreprise privée ou publique;Grande;Fabrication, production et distribution de produits chimiques;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1260
+Non;France;Entreprise privée ou publique;Grande;Fabrication, production et distribution de produits chimiques;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1261
+Non;France;Entreprise privée ou publique;Grande;Gestion des déchets;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1262
+Non;France;Entreprise privée ou publique;Grande;Gestion des déchets;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1263
+Non;France;Entreprise privée ou publique;Grande;Infrastructure des marchés financiers;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1264
+Non;France;Entreprise privée ou publique;Grande;Infrastructure des marchés financiers;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1265
+Non;France;Entreprise privée ou publique;Grande;Production transformation et distribution de denrées alimentaires;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1266
+Non;France;Entreprise privée ou publique;Grande;Production transformation et distribution de denrées alimentaires;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1267
+Non;France;Entreprise privée ou publique;Grande;Recherche;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1268
+Non;France;Entreprise privée ou publique;Grande;Recherche;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1269
+Non;France;Entreprise privée ou publique;Grande;Santé;-;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1270
+Non;France;Entreprise privée ou publique;Grande;Santé;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1271
+Non;France;Entreprise privée ou publique;Grande;Services postaux et d'expédition;-;-;-;-;Régulée EI;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1272
+Non;France;Entreprise privée ou publique;Grande;Services postaux et d'expédition;-;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1273
+Non;France;Entreprise privée ou publique;Grande;Transports;Aériens;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1274
+Non;France;Entreprise privée ou publique;Grande;Transports;Aériens;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1275
+Non;France;Entreprise privée ou publique;Grande;Transports;Ferroviaires;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1276
+Non;France;Entreprise privée ou publique;Grande;Transports;Ferroviaires;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1277
+Non;France;Entreprise privée ou publique;Grande;Transports;Par eau;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1278
+Non;France;Entreprise privée ou publique;Grande;Transports;Par eau;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1279
+Non;France;Entreprise privée ou publique;Grande;Transports;Routiers;-;-;-;Régulée EE;#MecanismeExemption, #ResilienceEntiteCritique, #SecuriteNationale;R1280
+Non;France;Entreprise privée ou publique;Grande;Transports;Routiers;Autre activité;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1281
+Non;France;Entreprise privée ou publique;Grande;Transports;Autre sous-secteur;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1282
+Non;France;Entreprise privée ou publique;Grande;Autre secteur d'activité;-;-;-;-;Non régulée;#MecanismeExemption, #CriteresDePossibleInclusion;R1283


### PR DESCRIPTION
En mettant les specs de travail en PROD, on s'assure que la comparaison v1 / v2 sera pertinente car basée sur un CSV quasi-complet.