### PR TITLE
[Éligibilité en CSV] Ajoute la règle « Extra - Établissement principal »

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FabriqueDeSpecifications.ts
@@ -10,6 +10,7 @@ import { RegleSecteurs } from "./regles/RegleSecteurs.ts";
 import { RegleSousSecteurs } from "./regles/RegleSousSecteurs.ts";
 import { RegleActivites } from "./regles/RegleActivites.ts";
 import { RegleFournitureDeServicesNumerique } from "./regles/RegleFournitureDeServicesNumerique.ts";
+import { RegleEtablissementPrincipal } from "./regles/RegleEtablissementPrincipal.ts";
 
 export class FabriqueDeSpecifications {
   transforme(texte: SpecificationTexte): Specifications {
@@ -22,6 +23,7 @@ export class FabriqueDeSpecifications {
       RegleSousSecteurs.nouvelle(texte),
       RegleActivites.nouvelle(texte),
       RegleFournitureDeServicesNumerique.nouvelle(texte),
+      RegleEtablissementPrincipal.nouvelle(texte),
     ].filter((s) => s !== undefined) as Regle[];
 
     const resultat = this.transformeResultat(texte);

--- a/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/FormatDesSpecificationsCSV.ts
@@ -7,6 +7,7 @@ export enum ClesDuCSV {
   "Sous-secteurs",
   "Activités",
   "Extra - Fourniture de service",
+  "Extra - Établissement principal",
   "Resultat",
 }
 

--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleEtablissementPrincipal.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleEtablissementPrincipal.ts
@@ -1,0 +1,36 @@
+import { estValeurVide, Regle } from "../Specifications.ts";
+import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
+import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
+import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
+import { AppartenancePaysUnionEuropeenne } from "../../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
+
+export class RegleEtablissementPrincipal implements Regle {
+  constructor(private readonly localisation: AppartenancePaysUnionEuropeenne) {}
+
+  evalue(reponses: EtatQuestionnaire): boolean {
+    const [paysDecision] = reponses.paysDecisionsCyber;
+    const [paysOperation] = reponses.paysOperationsCyber;
+    const [paysSalaries] = reponses.paysPlusGrandNombreSalaries;
+
+    return (
+      paysDecision === this.localisation ||
+      paysOperation === this.localisation ||
+      paysSalaries === this.localisation
+    );
+  }
+
+  static nouvelle(
+    texte: SpecificationTexte,
+  ): RegleEtablissementPrincipal | undefined {
+    const valeur = texte["Extra - Établissement principal"];
+
+    if (estValeurVide(valeur)) return;
+
+    if (valeur === "France") return new RegleEtablissementPrincipal("france");
+
+    if (valeur === "Autres États membres de l'Union Européenne")
+      return new RegleEtablissementPrincipal("autre");
+
+    throw new ErreurLectureDeRegle(valeur, "Extra - Établissement principal");
+  }
+}

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -626,6 +626,105 @@ describe("La fabrique de spécifications", () => {
     });
   });
 
+  describe("pour la règle « Extra - Établissement principal »", () => {
+    const entiteAvecDecisionEn = (
+      pays: AppartenancePaysUnionEuropeenne,
+    ): EtatQuestionnaire => ({
+      ...etatParDefaut,
+      paysDecisionsCyber: [pays],
+    });
+
+    const entiteQuiOpereEn = (
+      pays: AppartenancePaysUnionEuropeenne,
+    ): EtatQuestionnaire => ({
+      ...etatParDefaut,
+      paysOperationsCyber: [pays],
+    });
+
+    const entiteAvecSalariesBasesEn = (
+      pays: AppartenancePaysUnionEuropeenne,
+    ): EtatQuestionnaire => ({
+      ...etatParDefaut,
+      paysPlusGrandNombreSalaries: [pays],
+    });
+
+    it("instancie la règle « France »", () => {
+      expect(() =>
+        fabrique.transforme(
+          uneSpecification({
+            "Extra - Établissement principal": "France",
+            Resultat: "Régulée EE",
+          }),
+        ),
+      ).not.toThrowError();
+    });
+
+    it("instancie la règle « Autres États membres de l'Union Européenne »", () => {
+      expect(() =>
+        fabrique.transforme(
+          uneSpecification({
+            "Extra - Établissement principal":
+              "Autres États membres de l'Union Européenne",
+            Resultat: "Régulée EE",
+          }),
+        ),
+      ).not.toThrowError();
+    });
+
+    it("est un match dès qu'un pays de la réponse correspond au pays de la règle", () => {
+      const specsFrance: Specifications = fabrique.transforme(
+        uneSpecification({
+          "Extra - Établissement principal": "France",
+          Resultat: "Régulée EE",
+        }),
+      );
+
+      const decisionFr = entiteAvecDecisionEn("france");
+      expect(specsFrance.evalue(decisionFr)).toMatchObject(reguleEE());
+
+      const operationFr = entiteQuiOpereEn("france");
+      expect(specsFrance.evalue(operationFr)).toMatchObject(reguleEE());
+
+      const salariesFr = entiteAvecSalariesBasesEn("france");
+      expect(specsFrance.evalue(salariesFr)).toMatchObject(reguleEE());
+    });
+
+    it("ne match pas si aucun pays de la réponse ne correspond à celui de la règle", () => {
+      const specsFrance: Specifications = fabrique.transforme(
+        uneSpecification({
+          "Extra - Établissement principal": "France",
+          Resultat: "Régulée EE",
+        }),
+      );
+
+      const decisionAutreUE = entiteAvecDecisionEn("autre");
+
+      expect(specsFrance.evalue(decisionAutreUE)).toBe(undefined);
+    });
+
+    it("n'instancie pas de règle si aucune valeur n'est passée", () => {
+      const specs: Specifications = fabrique.transforme(
+        uneSpecification({
+          "Extra - Établissement principal": "-",
+          Resultat: "Régulée EE",
+        }),
+      );
+
+      expect(specs.nombreDeRegles()).toBe(0);
+    });
+
+    it("lève une exception si la valeur reçue n'est pas gérée", () => {
+      expect(() => {
+        fabrique.transforme(
+          uneSpecification({
+            "Extra - Établissement principal": "Jardin",
+            Resultat: "Régulée EE",
+          }),
+        );
+      }).toThrowError("Jardin");
+    });
+  });
+
   describe("pour le résultat", () => {
     it("sait instancier un résultat « Régulée EE»", () => {
       const specs: Specifications = fabrique.transforme(

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -700,6 +700,7 @@ function uneSpecification(
     "Sous-secteurs": "-",
     Activités: "-",
     "Extra - Fourniture de service": "-",
+    "Extra - Établissement principal": "-",
     Resultat: "CHAQUE TEST DOIT LE DÉFINIR",
     ...surcharge,
   };

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-ose-est-regulee-ee.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Resultat
-Oui;-;-;-;-;-;-;-;Régulée EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Extra - Établissement principal;Resultat
+Oui;-;-;-;-;-;-;-;-;Régulée EE

--- a/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
+++ b/anssi-nis2-ui/test/questionnaire/specifications/csv/specification-une-ligne.csv
@@ -1,2 +1,2 @@
-Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Resultat
-Oui;France;-;-;-;-;-;-;Régulée EE
+Designation OSE;Localisation;Type de structure;Taille;Secteurs;Sous-secteurs;Activités;Extra - Fourniture de service;Extra - Établissement principal;Resultat
+Oui;France;-;-;-;-;-;-;-;Régulée EE


### PR DESCRIPTION
Cette PR ajoute l'implémentation de la règle qui gère la colonne « Extra - Établissement principal » du CSV.

La règle est simple. Pas de complexité particulière.