### PR TITLE
Change le matching de la règle `RegleFournitureDeServicesNumerique`

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleFournitureDeServicesNumerique.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleFournitureDeServicesNumerique.ts
@@ -3,7 +3,6 @@ import { SpecificationTexte } from "../FormatDesSpecificationsCSV.ts";
 import { ErreurLectureDeRegle } from "./ErreurLectureDeRegle.ts";
 import { AppartenancePaysUnionEuropeenne } from "../../../../../commun/core/src/Domain/Simulateur/ChampsSimulateur.definitions.ts";
 import { EtatQuestionnaire } from "../../reducerQuestionnaire.ts";
-import { contientUnParmi } from "../../../../../commun/utils/services/commun.predicats.ts";
 
 export class RegleFournitureDeServicesNumerique implements Regle {
   constructor(
@@ -13,7 +12,9 @@ export class RegleFournitureDeServicesNumerique implements Regle {
   evalue(reponses: EtatQuestionnaire): boolean {
     const reponse = reponses.localisationFournitureServicesNumeriques;
 
-    return contientUnParmi(...this.localisationsAcceptees)(reponse);
+    if (reponse.length !== this.localisationsAcceptees.length) return false;
+
+    return reponse.every((r) => this.localisationsAcceptees.includes(r));
   }
 
   static nouvelle(

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -577,8 +577,8 @@ describe("La fabrique de spécifications", () => {
     });
 
     describe("lorsque la valeur est un cumul de réponses", () => {
-      it("instancie la règle en prenant en compte chaque réponse individuelle", () => {
-        const specsFranceEtUE = fabrique.transforme(
+      it("instancie une règle qui match si les réponses sont exactement la combinaison des valeurs individuelles attendues", () => {
+        const specsFranceEtAutreUE = fabrique.transforme(
           uneSpecification({
             "Extra - Fourniture de service":
               "France + Autres États membres de l'Union Européenne",
@@ -586,20 +586,24 @@ describe("La fabrique de spécifications", () => {
           }),
         );
 
-        expect(specsFranceEtUE.nombreDeRegles()).toBe(1);
+        expect(specsFranceEtAutreUE.nombreDeRegles()).toBe(1);
 
         expect(
-          specsFranceEtUE.evalue(entiteQuiFournitEn(["france"])),
+          specsFranceEtAutreUE.evalue(entiteQuiFournitEn(["france", "autre"])),
         ).toMatchObject(reguleEE());
+
         expect(
-          specsFranceEtUE.evalue(entiteQuiFournitEn(["autre"])),
-        ).toMatchObject(reguleEE());
-        expect(
-          specsFranceEtUE.evalue(entiteQuiFournitEn(["france", "horsue"])),
-        ).toMatchObject(reguleEE());
-        expect(specsFranceEtUE.evalue(entiteQuiFournitEn(["horsue"]))).toBe(
+          specsFranceEtAutreUE.evalue(entiteQuiFournitEn(["france"])),
+        ).toBe(undefined);
+        expect(specsFranceEtAutreUE.evalue(entiteQuiFournitEn(["autre"]))).toBe(
           undefined,
         );
+        expect(
+          specsFranceEtAutreUE.evalue(entiteQuiFournitEn(["france", "horsue"])),
+        ).toBe(undefined);
+        expect(
+          specsFranceEtAutreUE.evalue(entiteQuiFournitEn(["horsue"])),
+        ).toBe(undefined);
       });
     });
 


### PR DESCRIPTION
On veut que la règle match seulement si les réponses sont exactement les valeurs attendues.