### PR TITLE
Priorisation des spécifications retenues

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
@@ -11,20 +11,21 @@ export class EnsembleDeSpecifications {
   constructor(private readonly specifications: Specifications[]) {}
 
   premierPassant(reponses: EtatQuestionnaire): ResultatAvecAnalyse {
-    const premierPassant = this.specifications.find(
+    const passants = this.specifications.filter(
       (s) => s.evalue(reponses) !== undefined,
     );
 
-    if (!premierPassant) {
+    if (passants.length === 0) {
       const detail = JSON.stringify(reponses);
       throw new Error(
         `Aucune spécification ne correspond au questionnaire. ${detail}`,
       );
     }
+    const premierPassant = passants[0];
 
     return {
       resultat: premierPassant.resultat(),
-      specificationsRetenues: [premierPassant.code],
+      specificationsRetenues: passants.map((p) => p.code),
     };
   }
 

--- a/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
@@ -24,10 +24,10 @@ export class EnsembleDeSpecifications {
 
     passants.sort(prioriseLesSpecifications);
 
-    const premierPassant = passants[0];
+    const laPlusStricte = passants[0];
 
     return {
-      resultat: premierPassant.resultat(),
+      resultat: laPlusStricte.resultat(),
       specificationsRetenues: passants.map((p) => p.code),
     };
   }

--- a/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
@@ -10,7 +10,7 @@ export type ResultatAvecAnalyse = {
 export class EnsembleDeSpecifications {
   constructor(private readonly specifications: Specifications[]) {}
 
-  premierPassant(reponses: EtatQuestionnaire): ResultatAvecAnalyse {
+  evalue(reponses: EtatQuestionnaire): ResultatAvecAnalyse {
     const passants = this.specifications.filter(
       (s) => s.evalue(reponses) !== undefined,
     );

--- a/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
@@ -21,6 +21,9 @@ export class EnsembleDeSpecifications {
         `Aucune spécification ne correspond au questionnaire. ${detail}`,
       );
     }
+
+    passants.sort(prioriseLesSpecifications);
+
     const premierPassant = passants[0];
 
     return {
@@ -32,4 +35,11 @@ export class EnsembleDeSpecifications {
   nombre() {
     return this.specifications.length;
   }
+}
+
+function prioriseLesSpecifications(
+  a: Specifications,
+  b: Specifications,
+): number {
+  return a.ordreDePriorite() - b.ordreDePriorite();
 }

--- a/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
@@ -29,18 +29,21 @@ export class Specifications {
   }
 
   ordreDePriorite(): number {
-    if (
-      this._resultat.regulation === "Regule" &&
-      this._resultat.typeEntite === "EntiteEssentielle"
-    )
-      return 1;
+    const { regulation, typeEntite } = this._resultat;
 
-    if (
-      this._resultat.regulation === "Regule" &&
-      this._resultat.typeEntite === "EntiteImportante"
-    )
-      return 2;
+    if (regulation === "Regule") {
+      if (typeEntite === "EntiteEssentielle") return 1;
+      if (typeEntite === "EntiteImportante") return 2;
+      if (typeEntite === "AutreEtatMembreUE") return 3;
+      if (typeEntite === "EnregistrementUniquement") return 4;
+    }
 
-    return 9999;
+    if (regulation === "NonRegule") return 5;
+
+    if (regulation === "Incertain") return 6;
+
+    throw new Error(
+      `Impossible de déterminer la priorité de la spécification "${this.code}"`,
+    );
   }
 }

--- a/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/Specifications.ts
@@ -27,4 +27,20 @@ export class Specifications {
   resultat() {
     return this._resultat;
   }
+
+  ordreDePriorite(): number {
+    if (
+      this._resultat.regulation === "Regule" &&
+      this._resultat.typeEntite === "EntiteEssentielle"
+    )
+      return 1;
+
+    if (
+      this._resultat.regulation === "Regule" &&
+      this._resultat.typeEntite === "EntiteImportante"
+    )
+      return 2;
+
+    return 9999;
+  }
 }

--- a/anssi-nis2-ui/src/questionnaire/specifications/evalueEligibilite.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/evalueEligibilite.ts
@@ -8,5 +8,5 @@ export function evalueEligibilite(
 ): ResultatAvecAnalyse {
   const lecteur = new LecteurDeSpecifications();
   const specifications = lecteur.lis(cheminCsv);
-  return specifications.premierPassant(reponses);
+  return specifications.evalue(reponses);
 }

--- a/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { EnsembleDeSpecifications } from "../../../src/questionnaire/specifications/EnsembleDeSpecifications";
 import { RegleEntiteOSE } from "../../../src/questionnaire/specifications/regles/RegleEntiteOSE";
 import { Specifications } from "../../../src/questionnaire/specifications/Specifications";
@@ -7,12 +7,19 @@ import {
   etatParDefaut,
   EtatQuestionnaire,
 } from "../../../src/questionnaire/reducerQuestionnaire";
+import { RegleSecteurs } from "../../../src/questionnaire/specifications/regles/RegleSecteurs";
 
 describe("Un ensemble de spécifications", () => {
   const oseEstReguleeEE = new Specifications(
     [new RegleEntiteOSE(["oui"])],
     reguleEE(),
     "R1000",
+  );
+
+  const energieReguleeEE = new Specifications(
+    [new RegleSecteurs("energie")],
+    reguleEE(),
+    "R1001",
   );
 
   describe("lorsqu'une seule spécification correspond aux réponses", () => {
@@ -27,6 +34,25 @@ describe("Un ensemble de spécifications", () => {
 
       expect(resultat.specificationsRetenues.length).toBe(1);
       expect(resultat.specificationsRetenues[0]).toBe("R1000");
+    });
+  });
+
+  describe("lorsque plusieurs spécifications correspondent aux réponses", () => {
+    it("retient toutes les spécifications correspondantes", () => {
+      const deuxSpecs = new EnsembleDeSpecifications([
+        oseEstReguleeEE,
+        energieReguleeEE,
+      ]);
+
+      const reponseQuiMatchLesDeux: EtatQuestionnaire = {
+        ...etatParDefaut,
+        designationOperateurServicesEssentiels: ["oui"],
+        secteurActivite: ["energie"],
+      };
+
+      const resultat = deuxSpecs.premierPassant(reponseQuiMatchLesDeux);
+
+      expect(resultat.specificationsRetenues).toEqual(["R1000", "R1001"]);
     });
   });
 });

--- a/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
@@ -37,7 +37,7 @@ describe("Un ensemble de spécifications", () => {
         designationOperateurServicesEssentiels: ["oui"],
       };
 
-      const resultat = uneSeuleSpec.premierPassant(reponseOSEOui);
+      const resultat = uneSeuleSpec.evalue(reponseOSEOui);
 
       expect(resultat.specificationsRetenues.length).toBe(1);
       expect(resultat.specificationsRetenues[0]).toBe("R1000");
@@ -57,7 +57,7 @@ describe("Un ensemble de spécifications", () => {
         secteurActivite: ["energie"],
       };
 
-      const resultat = deuxSpecs.premierPassant(reponseQuiMatchLesDeux);
+      const resultat = deuxSpecs.evalue(reponseQuiMatchLesDeux);
 
       expect(resultat.specificationsRetenues).toEqual(["R1000", "R1001"]);
     });
@@ -113,7 +113,7 @@ describe("Un ensemble de spécifications", () => {
         secteurActivite: ["energie"],
       };
 
-      const resultat = ensembleDansLeDesordre.premierPassant(entiteEnergie);
+      const resultat = ensembleDansLeDesordre.evalue(entiteEnergie);
 
       expect(resultat.specificationsRetenues).toEqual([
         "Regulee EE (1)",

--- a/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { EnsembleDeSpecifications } from "../../../src/questionnaire/specifications/EnsembleDeSpecifications";
 import { RegleEntiteOSE } from "../../../src/questionnaire/specifications/regles/RegleEntiteOSE";
 import { Specifications } from "../../../src/questionnaire/specifications/Specifications";
-import { reguleEE } from "./aidesAuxTests";
+import { reguleEE, reguleEI } from "./aidesAuxTests";
 import {
   etatParDefaut,
   EtatQuestionnaire,
@@ -53,6 +53,37 @@ describe("Un ensemble de spécifications", () => {
       const resultat = deuxSpecs.premierPassant(reponseQuiMatchLesDeux);
 
       expect(resultat.specificationsRetenues).toEqual(["R1000", "R1001"]);
+    });
+
+    it("trie les spécifications retenues de la plus stricte à la moins stricte", () => {
+      const energieReguleeEE = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEE(),
+        "Regulee EE (1)",
+      );
+
+      const energieReguleeEI = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEI(),
+        "Regulee EI (2)",
+      );
+
+      const ensembleDansLeDesordre = new EnsembleDeSpecifications([
+        energieReguleeEI,
+        energieReguleeEE,
+      ]);
+
+      const entiteEnergie: EtatQuestionnaire = {
+        ...etatParDefaut,
+        secteurActivite: ["energie"],
+      };
+
+      const resultat = ensembleDansLeDesordre.premierPassant(entiteEnergie);
+
+      expect(resultat.specificationsRetenues).toEqual([
+        "Regulee EE (1)",
+        "Regulee EI (2)",
+      ]);
     });
   });
 });

--- a/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from "vitest";
 import { EnsembleDeSpecifications } from "../../../src/questionnaire/specifications/EnsembleDeSpecifications";
 import { RegleEntiteOSE } from "../../../src/questionnaire/specifications/regles/RegleEntiteOSE";
 import { Specifications } from "../../../src/questionnaire/specifications/Specifications";
-import { reguleEE, reguleEI } from "./aidesAuxTests";
+import {
+  neSaitPas,
+  nonRegulee,
+  reguleEE,
+  reguleEI,
+  reguleEnregistrementSeul,
+  reguleSansPrecision,
+} from "./aidesAuxTests";
 import {
   etatParDefaut,
   EtatQuestionnaire,
@@ -68,8 +75,36 @@ describe("Un ensemble de spécifications", () => {
         "Regulee EI (2)",
       );
 
+      const energieReguleeSansPrecision = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleSansPrecision(),
+        "Regulee sans précision (3)",
+      );
+
+      const energieReguleeEnregistrementSeul = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEnregistrementSeul(),
+        "Regulee enregistrement seul (4)",
+      );
+
+      const energieNonRegulee = new Specifications(
+        [new RegleSecteurs("energie")],
+        nonRegulee(),
+        "Non regulee (5)",
+      );
+
+      const energieNeSaitPas = new Specifications(
+        [new RegleSecteurs("energie")],
+        neSaitPas(),
+        "Ne sait pas (6)",
+      );
+
       const ensembleDansLeDesordre = new EnsembleDeSpecifications([
+        energieNonRegulee,
         energieReguleeEI,
+        energieReguleeEnregistrementSeul,
+        energieNeSaitPas,
+        energieReguleeSansPrecision,
         energieReguleeEE,
       ]);
 
@@ -83,6 +118,10 @@ describe("Un ensemble de spécifications", () => {
       expect(resultat.specificationsRetenues).toEqual([
         "Regulee EE (1)",
         "Regulee EI (2)",
+        "Regulee sans précision (3)",
+        "Regulee enregistrement seul (4)",
+        "Non regulee (5)",
+        "Ne sait pas (6)",
       ]);
     });
   });

--- a/anssi-nis2-ui/test/questionnaire/specifications/aidesAuxTests.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/aidesAuxTests.ts
@@ -18,3 +18,11 @@ export function reguleEE(): ResultatEligibilite {
     pointsAttention: { resumes: [], precisions: [] },
   };
 }
+
+export function reguleEI(): ResultatEligibilite {
+  return {
+    regulation: "Regule",
+    typeEntite: "EntiteImportante",
+    pointsAttention: { resumes: [], precisions: [] },
+  };
+}

--- a/anssi-nis2-ui/test/questionnaire/specifications/aidesAuxTests.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/aidesAuxTests.ts
@@ -26,3 +26,35 @@ export function reguleEI(): ResultatEligibilite {
     pointsAttention: { resumes: [], precisions: [] },
   };
 }
+
+export function reguleSansPrecision(): ResultatEligibilite {
+  return {
+    regulation: "Regule",
+    typeEntite: "AutreEtatMembreUE",
+    pointsAttention: { resumes: [], precisions: [] },
+  };
+}
+
+export function reguleEnregistrementSeul(): ResultatEligibilite {
+  return {
+    regulation: "Regule",
+    typeEntite: "EnregistrementUniquement",
+    pointsAttention: { resumes: [], precisions: [] },
+  };
+}
+
+export function nonRegulee(): ResultatEligibilite {
+  return {
+    regulation: "NonRegule",
+    typeEntite: "EnregistrementUniquement", // Peu importe le type
+    pointsAttention: { resumes: [], precisions: [] },
+  };
+}
+
+export function neSaitPas(): ResultatEligibilite {
+  return {
+    regulation: "Incertain",
+    typeEntite: "EnregistrementUniquement", // Peu importe le type
+    pointsAttention: { resumes: [], precisions: [] },
+  };
+}


### PR DESCRIPTION
Cette PR permet de n'appliquer que la spécification la plus stricte, dans le cas où plusieurs spécifications du CSV correspondraient aux réponses données.

Un exemple d'output 👇 

![image](https://github.com/betagouv/anssi-nis2/assets/24898521/b07be7ff-3a67-4598-b170-df43dfb994a6)


On voit dans `resultat` qu'on est sur du « Régulée EE ».
Et dans `specificationsRetenues` on comprend que `R1017`, `R1024` et `R1028` on été retenues.
C'est la première qui est appliquée : `R10107`. Et elle correspond bien à un résultat « Régulée EE »