### PR TITLE
Logue en INFO le cas du « Non régulée »

### DIFF
--- a/anssi-nis2-ui/src/Components/Simulateur/compareEtEnvoieVersSentry.tsx
+++ b/anssi-nis2-ui/src/Components/Simulateur/compareEtEnvoieVersSentry.tsx
@@ -18,11 +18,15 @@ export function compareEtEnvoieVersSentry(
     // @ts-ignore
     const typeEntiteV1 = regulationV1?.typeEntite;
 
+    const estNonRegulee =
+      regulationV1.decision === "NonRegule" &&
+      resultatV2.resultat.regulation === "NonRegule";
+
     const estIdentique =
       resultatV2.resultat.regulation === regulationV1.decision &&
       resultatV2.resultat.typeEntite === typeEntiteV1;
 
-    const niveauLog = estIdentique ? "info" : "error";
+    const niveauLog = estIdentique || estNonRegulee ? "info" : "error";
 
     const titre = estIdentique
       ? "MATCH COMPARAISON V1 & V2"


### PR DESCRIPTION
Pour le non régulé, inutile de comparer le type d'entité, car il est différent entre v1 et v2.