### PR TITLE
Retire « Administration publique » des secteurs

### DIFF
--- a/anssi-nis2-ui/src/References/LibellesActivites.ts
+++ b/anssi-nis2-ui/src/References/LibellesActivites.ts
@@ -4,19 +4,12 @@ export const libellesActivites: Record<Activite, string> = {
   acteurDuMarche:
     "Acteurs du marché fournissant des services d'agrégation, de " +
     "participation active de la demande ou de stockage d'énergie",
-  administrationPouvoirsPublicsCentraux:
-    "Entités de l'administration publique des pouvoirs publics centraux " +
-    "définies comme telles par un État membre conformément au droit national",
-  administrationPubliqueNiveauRegional:
-    "Entités de l'administration publique au niveau régional définies comme " +
-    "telles par un État membre conformément au droit national",
   autoritesRoutieresControleGestionCirculation:
     "Autorités routières chargées du contrôle de la gestion de la " +
     "circulation, à l'exclusion des entités publiques pour lesquelles la " +
     "gestion de la circulation ou l'exploitation de systèmes de transport " +
     "intelligents constituent une partie non essentielle de leur activité " +
     "générale",
-  autreActiviteAdministrationPublique: "Autre activité",
   autreActiviteConstructionVehiculesAutomobilesRemorquesSemi: "Autre activité",
   autreActiviteEauPotable: "Autre activité",
   autreActiviteEauxUsees: "Autre activité",

--- a/anssi-nis2-ui/src/References/LibellesSecteursActivite.ts
+++ b/anssi-nis2-ui/src/References/LibellesSecteursActivite.ts
@@ -1,7 +1,6 @@
 import { SecteurActivite } from "../../../commun/core/src/Domain/Simulateur/SecteurActivite.definitions";
 
 export const libellesSecteursActivite: Record<SecteurActivite, string> = {
-  administrationPublique: "Administration publique / administration centrale",
   banqueSecteurBancaire: "Banques (secteur bancaire)",
   eauPotable: "Eau potable",
   eauxUsees: "Eaux usées",

--- a/anssi-nis2-ui/src/References/ListeDescriptionsActivites.ts
+++ b/anssi-nis2-ui/src/References/ListeDescriptionsActivites.ts
@@ -7,7 +7,6 @@ export const listeDescriptionsActivites: Record<
   Activite,
   DescriptionActivite[]
 > = {
-  autreActiviteAdministrationPublique: [],
   autreActiviteConstructionVehiculesAutomobilesRemorquesSemi: [],
   autreActiviteEauPotable: [],
   autreActiviteEauxUsees: [],
@@ -68,8 +67,6 @@ export const listeDescriptionsActivites: Record<
         "la conservation de cette énergie et la reconversion ultérieure de celle-ci en énergie électrique ou son utilisation en tant qu'autre vecteur d’énergie.",
     },
   ],
-  administrationPouvoirsPublicsCentraux: [],
-  administrationPubliqueNiveauRegional: [],
   autoritesRoutieresControleGestionCirculation: [
     {
       titre: "Autorité routière",

--- a/commun/core/src/Domain/Simulateur/Activite.definitions.ts
+++ b/commun/core/src/Domain/Simulateur/Activite.definitions.ts
@@ -1,5 +1,4 @@
 import {
-  ValeursActivitesAdministrationPublique,
   ValeursActivitesConstructionVehiculesAutomobiles,
   ValeursActivitesEauPotable,
   ValeursActivitesEauUsees,
@@ -72,8 +71,6 @@ export type ActivitesInfrastructureNumerique =
   (typeof ValeursActivitesInfrastructureNumerique)[number];
 export type ActivitesGestionServicesTic =
   (typeof ValeursActivitesGestionServicesTic)[number];
-export type ActivitesAdministrationPublique =
-  (typeof ValeursActivitesAdministrationPublique)[number];
 export type ActivitesEspace = (typeof ValeursActivitesEspace)[number];
 export type ActivitesServicesPostauxExpedition =
   (typeof ValeursActivitesServicesPostauxExpedition)[number];
@@ -116,7 +113,6 @@ export type Activite =
   | ActivitesEauUsees
   | ActivitesInfrastructureNumerique
   | ActivitesGestionServicesTic
-  | ActivitesAdministrationPublique
   | ActivitesEspace
   // Annexe 2
   | ActivitesServicesPostauxExpedition
@@ -161,7 +157,6 @@ export interface ActivitesPourSecteur
   eauPotable: ActivitesEauPotable;
   eauUsees: ActivitesEauUsees;
   infrastructureNumerique: ActivitesInfrastructureNumerique;
-  administrationPublique: ActivitesAdministrationPublique;
   espace: ActivitesEspace;
   servicesPostauxExpedition: ActivitesServicesPostauxExpedition;
   gestionDechets: ActivitesGestionDechets;

--- a/commun/core/src/Domain/Simulateur/Activite.operations.ts
+++ b/commun/core/src/Domain/Simulateur/Activite.operations.ts
@@ -1,6 +1,5 @@
 import { Activite } from "./Activite.definitions";
 import {
-  ValeursActivitesAdministrationPublique,
   ValeursActivitesConstructionVehiculesAutomobiles,
   ValeursActivitesEauPotable,
   ValeursActivitesEauUsees,
@@ -39,7 +38,6 @@ export const activitesParSecteurEtSousSecteur: Record<
   SecteurSimple | SousSecteurActivite,
   readonly Activite[]
 > = {
-  administrationPublique: ValeursActivitesAdministrationPublique,
   autreSecteurActivite: [],
   autreSousSecteurEnergie: [],
   autreSousSecteurFabrication: [],

--- a/commun/core/src/Domain/Simulateur/Activite.valeurs.ts
+++ b/commun/core/src/Domain/Simulateur/Activite.valeurs.ts
@@ -124,11 +124,6 @@ export const ValeursActivitesGestionServicesTic = [
   "fournisseurServicesSecuriteGeres",
   "autreActiviteGestionServicesTic",
 ] as const;
-export const ValeursActivitesAdministrationPublique = [
-  "administrationPouvoirsPublicsCentraux",
-  "administrationPubliqueNiveauRegional",
-  "autreActiviteAdministrationPublique",
-] as const;
 export const ValeursActivitesEspace = [
   "exploitantsInfrastructureTerrestresFournitureServicesSpaciaux",
   "autreActiviteEspace",
@@ -231,7 +226,6 @@ export const ValeursActivites =
     ...ValeursActivitesEauUsees,
     ...ValeursActivitesInfrastructureNumerique,
     ...ValeursActivitesGestionServicesTic,
-    ...ValeursActivitesAdministrationPublique,
     ...ValeursActivitesEspace,
     // Annexe 2
     ...ValeursActivitesServicesPostauxExpedition,

--- a/commun/core/src/Domain/Simulateur/SecteurActivite.valeurs.ts
+++ b/commun/core/src/Domain/Simulateur/SecteurActivite.valeurs.ts
@@ -16,7 +16,6 @@ export const ValeursSecteursAvecBesoinLocalisationRepresentant = [
 ] as const;
 
 export const ValeursSecteursActivitesAnnexe1 = [
-  "administrationPublique",
   "energie",
   "transports",
   "banqueSecteurBancaire",


### PR DESCRIPTION
Les administrations publiques seront gérées dans le parcours dédié.