### PR TITLE
Correction enchainement des étapes du questionnaire

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -60,7 +60,7 @@ export const etatParDefaut: EtatQuestionnaire = {
   paysPlusGrandNombreSalaries: [],
 };
 
-const contientActiviteFournisseurNumeriquePublic = contientUnParmi(
+const doitPasserParLocalisationFournitureServicesNumeriques = contientUnParmi(
   "fournisseurReseauxCommunicationElectroniquesPublics",
   "fournisseurServiceCommunicationElectroniquesPublics",
 );
@@ -139,7 +139,9 @@ const valideEtape = (
         contientUnSecteurTicOuFournisseurNumerique(etat.secteurActivite) ||
           contientActiviteFournisseurServicesNumeriques(action.activites)
           ? "localisationEtablissementPrincipal"
-          : contientActiviteFournisseurNumeriquePublic(action.activites)
+          : doitPasserParLocalisationFournitureServicesNumeriques(
+              action.activites,
+            )
           ? "localisationFournitureServicesNumeriques"
           : "resultat",
         { activites: action.activites },
@@ -147,7 +149,7 @@ const valideEtape = (
 
     case "VALIDE_ETAPE_LOCALISATION_ETABLISSEMENT_PRINCIPAL":
       return vaVers(
-        contientActiviteFournisseurNumeriquePublic(etat.activites)
+        doitPasserParLocalisationFournitureServicesNumeriques(etat.activites)
           ? "localisationFournitureServicesNumeriques"
           : "resultat",
         {

--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -146,11 +146,16 @@ const valideEtape = (
       );
 
     case "VALIDE_ETAPE_LOCALISATION_ETABLISSEMENT_PRINCIPAL":
-      return vaVers("resultat", {
-        paysDecisionsCyber: action.paysDecision,
-        paysOperationsCyber: action.paysOperation,
-        paysPlusGrandNombreSalaries: action.paysSalaries,
-      });
+      return vaVers(
+        contientActiviteFournisseurNumeriquePublic(etat.activites)
+          ? "localisationFournitureServicesNumeriques"
+          : "resultat",
+        {
+          paysDecisionsCyber: action.paysDecision,
+          paysOperationsCyber: action.paysOperation,
+          paysPlusGrandNombreSalaries: action.paysSalaries,
+        },
+      );
 
     case "VALIDE_ETAPE_LOCALISATION_SERVICES_NUMERIQUES":
       return vaVers("resultat", {

--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -91,23 +91,28 @@ const valideEtape = (
   switch (action.type) {
     case "VALIDE_ETAPE_PREALABLE":
       return vaVers("designationOperateurServicesEssentiels");
+
     case "VALIDE_ETAPE_DESIGNATION":
       return vaVers("appartenanceUnionEuropeenne", {
         designationOperateurServicesEssentiels: action.designations,
       });
+
     case "VALIDE_ETAPE_APPARTENANCE_UE":
       return vaVers("typeStructure", {
         appartenancePaysUnionEuropeenne: action.appartenances,
       });
+
     case "VALIDE_ETAPE_TYPE_STRUCTURE":
       return vaVers("tailleEntitePrivee", {
         typeStructure: action.types,
       });
+
     case "VALIDE_ETAPE_TAILLE_ENTITE_PRIVEE":
       return vaVers("secteursActivite", {
         trancheNombreEmployes: action.nombreEmployes,
         trancheChiffreAffaire: action.chiffreAffaire,
       });
+
     case "VALIDE_ETAPE_SECTEURS_ACTIVITE":
       return vaVers(
         tous(estSecteurAutre)(action.secteurs)
@@ -115,10 +120,9 @@ const valideEtape = (
           : certains(estUnSecteurAvecDesSousSecteurs)(action.secteurs)
           ? "sousSecteursActivite"
           : "activites",
-        {
-          secteurActivite: action.secteurs,
-        },
+        { secteurActivite: action.secteurs },
       );
+
     case "VALIDE_ETAPE_SOUS_SECTEURS_ACTIVITE":
       return vaVers(
         etat.secteurActivite.every(
@@ -126,10 +130,9 @@ const valideEtape = (
         ) && action.sousSecteurs.every(estSousSecteurAutre)
           ? "resultat"
           : "activites",
-        {
-          sousSecteurActivite: action.sousSecteurs,
-        },
+        { sousSecteurActivite: action.sousSecteurs },
       );
+
     case "VALIDE_ETAPE_ACTIVITES":
       return vaVers(
         contientUnSecteurTicOuFournisseurNumerique(etat.secteurActivite) ||
@@ -138,20 +141,21 @@ const valideEtape = (
           : contientActiviteFournisseurNumeriquePublic(action.activites)
           ? "localisationFournitureServicesNumeriques"
           : "resultat",
-        {
-          activites: action.activites,
-        },
+        { activites: action.activites },
       );
+
     case "VALIDE_ETAPE_LOCALISATION_ETABLISSEMENT_PRINCIPAL":
       return vaVers("resultat", {
         paysDecisionsCyber: action.paysDecision,
         paysOperationsCyber: action.paysOperation,
         paysPlusGrandNombreSalaries: action.paysSalaries,
       });
+
     case "VALIDE_ETAPE_LOCALISATION_SERVICES_NUMERIQUES":
       return vaVers("resultat", {
         localisationFournitureServicesNumeriques: action.pays,
       });
+
     default:
       return {};
   }
@@ -159,8 +163,8 @@ const valideEtape = (
 
 export const reducerQuestionnaire = (
   etat: EtatQuestionnaire,
-  actionTraitee: ActionQuestionnaire | ActionUndo,
+  action: ActionQuestionnaire | ActionUndo,
 ): EtatQuestionnaire => ({
   ...etat,
-  ...valideEtape(actionTraitee, etat),
+  ...valideEtape(action, etat),
 });

--- a/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
+++ b/anssi-nis2-ui/src/questionnaire/reducerQuestionnaire.ts
@@ -74,6 +74,7 @@ const contientActiviteFournisseurServicesNumeriques = contientUnParmi(
   "fournisseurServicesInformatiqueNuage",
   "fournisseurServiceCentresDonnees",
   "fournisseurReseauxDiffusionContenu",
+  "fournisseurServicesEnregristrementNomDomaine",
 );
 
 const vaVers = (

--- a/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
@@ -193,6 +193,7 @@ describe("Le reducer du Questionnaire", () => {
         "fournisseurServicesInformatiqueNuage",
         "fournisseurServiceCentresDonnees",
         "fournisseurReseauxDiffusionContenu",
+        "fournisseurServicesEnregristrementNomDomaine",
       ];
       it.each(activitesVersLocalisationEtablissement)(
         `... si l'activité « %s » est présente`,

--- a/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/reducerQuestionnaire.spec.ts
@@ -260,7 +260,31 @@ describe("Le reducer du Questionnaire", () => {
       expect(etat.paysPlusGrandNombreSalaries).toEqual(["france"]);
     });
 
-    it("navigue vers l'étape « Résultat »", () => {
+    describe("navigue vers l'étape « Localisation de la fourniture des services numériques »", () => {
+      const activitesVersLocalisationServiceNumerique: Activite[] = [
+        "fournisseurReseauxCommunicationElectroniquesPublics",
+        "fournisseurServiceCommunicationElectroniquesPublics",
+      ];
+      it.each(activitesVersLocalisationServiceNumerique)(
+        `... si l'activité « %s » est présente car elle a été sélectionnée à l'étape « Activités »`,
+        (activite) => {
+          const activitesNecessitantLesDeuxEtapesExtra: Activite[] = [
+            "fournisseurServicesDNS", // Fournisseur DNS fait passer par « Établissement principal activite »
+            activite, // … puis on ajoute l'activité qui doit faire passer par « Fourniture des services numériques »
+          ];
+          const etat = executer([
+            valideActivites(activitesNecessitantLesDeuxEtapesExtra),
+            valideLocalisationEtablissementPrincipal(["france"], [], []),
+          ]);
+
+          expect(etat.etapeCourante).toBe(
+            "localisationFournitureServicesNumeriques",
+          );
+        },
+      );
+    });
+
+    it("autrement, navigue vers l'étape « Résultat »", () => {
       const etat = executer([
         valideLocalisationEtablissementPrincipal(["france"], [], []),
       ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -26581,10 +26581,11 @@
       "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
     },
     "node_modules/vite": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
-      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
+      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",


### PR DESCRIPTION
Cette PR permet à MonEspaceNIS2 d'afficher correctement les 2 étapes « extra » 👇 

![image](https://github.com/user-attachments/assets/bb0c5db4-c4fd-4936-b256-173a5af9b664)


Avant cette PR, seule une étape parmi les 2 était affichée au maximum.

Il faut afficher les 2 étapes pour récolter toutes les réponses et calculer la bonne décision d'éligibilité.