### PR TITLE
[CORRECTION] Interprète correctement la réponse « Gestionnaire de réseau de transport »

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/regles/RegleActivites.ts
@@ -21,6 +21,8 @@ export class RegleActivites implements Regle {
 
     return valeur === "Autre activité"
       ? recupereAutreActivite(texte)
+      : valeur === "Gestionnaire de réseau de transport"
+      ? recupereReseauTransport(texte)
       : recupereActiviteIdentifiee(valeur);
   }
 }
@@ -117,4 +119,18 @@ const recupereActiviteIdentifiee = (valeur: string) => {
 
   const [id] = activiteCorrespondante;
   return new RegleActivites(id as Activite);
+};
+
+const recupereReseauTransport = (texte: SpecificationTexte) => {
+  const sousSecteur = texte["Sous-secteurs"];
+
+  if (sousSecteur === "Électricité")
+    return new RegleActivites("gestionnaireReseauTransportElectricite");
+  if (sousSecteur === "Gaz")
+    return new RegleActivites("gestionnaireReseauTransportGaz");
+
+  throw new ErreurLectureDeRegle(
+    `"Gestionnaire de réseau de transport" pour le sous-secteur : ${sousSecteur}`,
+    "Activités",
+  );
 };

--- a/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/FabriqueDeSpecifications.spec.ts
@@ -17,6 +17,7 @@ import { libellesSousSecteursActivite } from "../../../src/References/LibellesSo
 import {
   autresActivites,
   CasDeTest,
+  energie,
   fabrication,
   fournisseursNumeriques,
   gestionDesServicesTIC,
@@ -506,6 +507,7 @@ describe("La fabrique de spécifications", () => {
       ...gestionDesServicesTIC,
       ...fournisseursNumeriques,
       ...fabrication,
+      ...energie,
       ...autresActivites,
     ];
 

--- a/anssi-nis2-ui/test/questionnaire/specifications/casDeTests.activites.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/casDeTests.activites.ts
@@ -127,6 +127,25 @@ export const fournisseursNumeriques: CasDeTest[] = [
   },
 ];
 
+export const energie: CasDeTest[] = [
+  {
+    libelleActivite: "Gestionnaire de réseau de transport",
+    activite: "gestionnaireReseauTransportElectricite",
+    libelleSecteur: "Énergie",
+    secteur: "energie",
+    libelleSousSecteur: "Électricité",
+    sousSecteur: "electricite",
+  },
+  {
+    libelleActivite: "Gestionnaire de réseau de transport",
+    activite: "gestionnaireReseauTransportGaz",
+    libelleSecteur: "Énergie",
+    secteur: "energie",
+    libelleSousSecteur: "Gaz",
+    sousSecteur: "gaz",
+  },
+];
+
 export const fabrication: CasDeTest[] = [
   {
     libelleActivite:


### PR DESCRIPTION

C'est un libellé de réponse qui se trouve à la fois dans « Gaz » et « Électricité ». Le problème était que le code utilisait systématiquement la valeur `gestionnaireReseauTransportGaz` du Gaz. À présent, on fait bien la distinction entre les 2 sous-secteurs.

ℹ️ J'ai vérifié : le problème n'est PAS présent ailleurs
Autrement dit : je n'ai pas trouvé d'autres cas de « libellés identiques » qui mettraient la logique en défaut