### PR TITLE
[CORRECTION] Spécifie le chemin vers le `knexfile`

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: npm start
-postdeploy: npx knex migrate:latest
+postdeploy: npx knex migrate:latest --knexfile anssi-nis2-api/knexfile.ts


### PR DESCRIPTION
C'est nécessaire car sur le PaaS, ce `postdeploy` est exécuté depuis la racine du repo.