### PR TITLE
[CORRECTION] Passe correctement les `headers` à la fonction de d'extraction IP

### DIFF
--- a/anssi-nis2-api/src/http/requeteHttp.ts
+++ b/anssi-nis2-api/src/http/requeteHttp.ts
@@ -1,5 +1,7 @@
-export function extraisIp(headersExpress: Express.Request) {
-  const ips = headersExpress["x-forwarded-for"]?.split(", ");
+import * as http from "http";
+
+export function extraisIp(headersExpress: http.IncomingHttpHeaders) {
+  const ips = (headersExpress["x-forwarded-for"] as string)?.split(", ");
 
   if (!ips) return {};
 

--- a/anssi-nis2-api/src/serveur.express.ts
+++ b/anssi-nis2-api/src/serveur.express.ts
@@ -49,7 +49,7 @@ const activeFiltrageIp = (app: Express) => {
 
   app.use(
     IpFilter(ipAutorisees, {
-      detectIp: (requete) => extraisIp(requete).waf,
+      detectIp: (requete) => extraisIp(requete.headers).waf,
       mode: "allow",
       log: false,
     }),


### PR DESCRIPTION
... car on passait toute la `Request`.