### PR TITLE
[CORRECTION] Fusionne correctement les points d'attention

### DIFF
--- a/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
@@ -22,27 +22,10 @@ export class EnsembleDeSpecifications {
       );
     }
 
-    passants.sort(prioriseLesSpecifications);
+    const resultat = choisisLeResultat(passants);
 
-    const tousLesResumes = passants.flatMap(
-      (p) => p.resultat().pointsAttention.resumes,
-    );
-    const toutesPrecisions = passants.flatMap(
-      (p) => p.resultat().pointsAttention.precisions,
-    );
-
-    const laPlusStricte = passants[0];
-
-    const resultatPlusStrict = laPlusStricte.resultat();
     return {
-      resultat: {
-        ...resultatPlusStrict,
-        pointsAttention: {
-          ...resultatPlusStrict.pointsAttention,
-          resumes: [...new Set(tousLesResumes)],
-          precisions: [...new Set(toutesPrecisions)],
-        },
-      },
+      resultat,
       specificationsRetenues: passants.map((p) => p.code),
     };
   }
@@ -50,6 +33,31 @@ export class EnsembleDeSpecifications {
   nombre() {
     return this.specifications.length;
   }
+}
+
+function choisisLeResultat(passants: Specifications[]) {
+  passants.sort(prioriseLesSpecifications);
+
+  const tousLesResumes = passants.flatMap(
+    (p) => p.resultat().pointsAttention.resumes,
+  );
+  const toutesPrecisions = passants.flatMap(
+    (p) => p.resultat().pointsAttention.precisions,
+  );
+
+  const resumesUniques = [...new Set(tousLesResumes)];
+  const precisionsUniques = [...new Set(toutesPrecisions)];
+
+  const laPlusStricte = passants[0];
+  const resultatPlusStrict = laPlusStricte.resultat();
+
+  return {
+    ...resultatPlusStrict,
+    pointsAttention: {
+      resumes: resumesUniques,
+      precisions: precisionsUniques,
+    },
+  };
 }
 
 function prioriseLesSpecifications(

--- a/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
@@ -27,6 +27,9 @@ export class EnsembleDeSpecifications {
     const tousLesResumes = passants.flatMap(
       (p) => p.resultat().pointsAttention.resumes,
     );
+    const toutesPrecisions = passants.flatMap(
+      (p) => p.resultat().pointsAttention.precisions,
+    );
 
     const laPlusStricte = passants[0];
 
@@ -37,6 +40,7 @@ export class EnsembleDeSpecifications {
         pointsAttention: {
           ...resultatPlusStrict.pointsAttention,
           resumes: tousLesResumes,
+          precisions: toutesPrecisions,
         },
       },
       specificationsRetenues: passants.map((p) => p.code),

--- a/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
@@ -39,8 +39,8 @@ export class EnsembleDeSpecifications {
         ...resultatPlusStrict,
         pointsAttention: {
           ...resultatPlusStrict.pointsAttention,
-          resumes: tousLesResumes,
-          precisions: toutesPrecisions,
+          resumes: [...new Set(tousLesResumes)],
+          precisions: [...new Set(toutesPrecisions)],
         },
       },
       specificationsRetenues: passants.map((p) => p.code),

--- a/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
+++ b/anssi-nis2-ui/src/questionnaire/specifications/EnsembleDeSpecifications.ts
@@ -24,10 +24,21 @@ export class EnsembleDeSpecifications {
 
     passants.sort(prioriseLesSpecifications);
 
+    const tousLesResumes = passants.flatMap(
+      (p) => p.resultat().pointsAttention.resumes,
+    );
+
     const laPlusStricte = passants[0];
 
+    const resultatPlusStrict = laPlusStricte.resultat();
     return {
-      resultat: laPlusStricte.resultat(),
+      resultat: {
+        ...resultatPlusStrict,
+        pointsAttention: {
+          ...resultatPlusStrict.pointsAttention,
+          resumes: tousLesResumes,
+        },
+      },
       specificationsRetenues: passants.map((p) => p.code),
     };
   }

--- a/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
@@ -124,5 +124,33 @@ describe("Un ensemble de spécifications", () => {
         "Ne sait pas (6)",
       ]);
     });
+
+    it("cumule les résumés de points d'attentions de toutes les spécifications retenues", () => {
+      const energie1 = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEE(["NumeriqueUE"]),
+        "Regulee EE (1)",
+      );
+
+      const energie2 = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEI(["RepresentantUE"]),
+        "Regulee EI (2)",
+      );
+
+      const toutes = new EnsembleDeSpecifications([energie2, energie1]);
+
+      const entiteEnergie: EtatQuestionnaire = {
+        ...etatParDefaut,
+        secteurActivite: ["energie"],
+      };
+
+      const resultat = toutes.evalue(entiteEnergie);
+
+      expect(resultat.resultat.pointsAttention.resumes).toEqual([
+        "NumeriqueUE",
+        "RepresentantUE",
+      ]);
+    });
   });
 });

--- a/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
@@ -152,5 +152,33 @@ describe("Un ensemble de spécifications", () => {
         "RepresentantUE",
       ]);
     });
+
+    it("cumule les précisions de points d'attentions de toutes les spécifications retenues", () => {
+      const energie1 = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEE([], ["OSE"]),
+        "Regulee EE (1)",
+      );
+
+      const energie2 = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEI([], ["DORA"]),
+        "Regulee EI (2)",
+      );
+
+      const toutes = new EnsembleDeSpecifications([energie2, energie1]);
+
+      const entiteEnergie: EtatQuestionnaire = {
+        ...etatParDefaut,
+        secteurActivite: ["energie"],
+      };
+
+      const resultat = toutes.evalue(entiteEnergie);
+
+      expect(resultat.resultat.pointsAttention.precisions).toEqual([
+        "OSE",
+        "DORA",
+      ]);
+    });
   });
 });

--- a/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/EnsembleDeSpecifications.spec.ts
@@ -180,5 +180,57 @@ describe("Un ensemble de spécifications", () => {
         "DORA",
       ]);
     });
+
+    it("ne fait pas de doublons dans les résumés de points d'attentions", () => {
+      const energie1 = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEE(["NumeriqueUE"]),
+        "Regulee EE (1)",
+      );
+
+      const energie2 = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEI(["NumeriqueUE"]),
+        "Regulee EI (2)",
+      );
+
+      const toutes = new EnsembleDeSpecifications([energie2, energie1]);
+
+      const entiteEnergie: EtatQuestionnaire = {
+        ...etatParDefaut,
+        secteurActivite: ["energie"],
+      };
+
+      const resultat = toutes.evalue(entiteEnergie);
+
+      expect(resultat.resultat.pointsAttention.resumes).toEqual([
+        "NumeriqueUE",
+      ]);
+    });
+
+    it("ne fait pas de doublons dans les précisions de points d'attentions", () => {
+      const energie1 = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEE([], ["OSE"]),
+        "Regulee EE (1)",
+      );
+
+      const energie2 = new Specifications(
+        [new RegleSecteurs("energie")],
+        reguleEI([], ["OSE"]),
+        "Regulee EI (2)",
+      );
+
+      const toutes = new EnsembleDeSpecifications([energie2, energie1]);
+
+      const entiteEnergie: EtatQuestionnaire = {
+        ...etatParDefaut,
+        secteurActivite: ["energie"],
+      };
+
+      const resultat = toutes.evalue(entiteEnergie);
+
+      expect(resultat.resultat.pointsAttention.precisions).toEqual(["OSE"]);
+    });
   });
 });

--- a/anssi-nis2-ui/test/questionnaire/specifications/aidesAuxTests.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/aidesAuxTests.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import {
+  PointsAttentionPrecis,
   ResultatEligibilite,
   ResumesPointsAttention,
 } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions";
@@ -16,21 +17,23 @@ export const leCSVDeProd = (nom: string) => {
 
 export function reguleEE(
   resumes: ResumesPointsAttention[] = [],
+  precisions: PointsAttentionPrecis[] = [],
 ): ResultatEligibilite {
   return {
     regulation: "Regule",
     typeEntite: "EntiteEssentielle",
-    pointsAttention: { resumes: resumes, precisions: [] },
+    pointsAttention: { resumes: resumes, precisions: precisions },
   };
 }
 
 export function reguleEI(
   resumes: ResumesPointsAttention[] = [],
+  precisions: PointsAttentionPrecis[] = [],
 ): ResultatEligibilite {
   return {
     regulation: "Regule",
     typeEntite: "EntiteImportante",
-    pointsAttention: { resumes: resumes, precisions: [] },
+    pointsAttention: { resumes: resumes, precisions: precisions },
   };
 }
 

--- a/anssi-nis2-ui/test/questionnaire/specifications/aidesAuxTests.ts
+++ b/anssi-nis2-ui/test/questionnaire/specifications/aidesAuxTests.ts
@@ -1,5 +1,8 @@
 import { readFileSync } from "node:fs";
-import { ResultatEligibilite } from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions";
+import {
+  ResultatEligibilite,
+  ResumesPointsAttention,
+} from "../../../../commun/core/src/Domain/Simulateur/Regulation.definitions";
 
 export const leCSV = (nom: string) => {
   const chemin = "./test/questionnaire/specifications/csv/" + nom;
@@ -11,19 +14,23 @@ export const leCSVDeProd = (nom: string) => {
   return readFileSync(chemin).toString("utf-8");
 };
 
-export function reguleEE(): ResultatEligibilite {
+export function reguleEE(
+  resumes: ResumesPointsAttention[] = [],
+): ResultatEligibilite {
   return {
     regulation: "Regule",
     typeEntite: "EntiteEssentielle",
-    pointsAttention: { resumes: [], precisions: [] },
+    pointsAttention: { resumes: resumes, precisions: [] },
   };
 }
 
-export function reguleEI(): ResultatEligibilite {
+export function reguleEI(
+  resumes: ResumesPointsAttention[] = [],
+): ResultatEligibilite {
   return {
     regulation: "Regule",
     typeEntite: "EntiteImportante",
-    pointsAttention: { resumes: [], precisions: [] },
+    pointsAttention: { resumes: resumes, precisions: [] },
   };
 }
 


### PR DESCRIPTION
Lorsque des réponses correspondent à plusieurs lignes de spécifications, il faut retenir seulement le résultat le plus strict (c'est déjà implémenté) et fusionner tous les points d'attention (pas implémenté).

Cette PR corrige ce dernier point en fusionnant les points d'attention.
On fait bien attention à ne pas faire de doublons.