### PR TITLE
Copie le fichier CSV près de son adaptateur

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: npm start
-postdeploy: npx knex migrate:latest --knexfile anssi-nis2-api/knexfile.ts
+postdeploy: npx knex migrate:latest --knexfile anssi-nis2-api/knexfile.ts && cp "commun/core/src/Domain/Questionnaire/specifications-completes.csv" "anssi-nis2-api/dist/anssi-nis2-api/src/adaptateurs"


### PR DESCRIPTION
… aussi chez Scalingo.
C'était fait dans le `package.json` pour le dev local, il faut également le faire chez Scalingo.