### PR TITLE
[CORRECTION] Déplace l'exécution de la copie du CSV

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: npm start
-postdeploy: npx knex migrate:latest --knexfile anssi-nis2-api/knexfile.ts && cp "commun/core/src/Domain/Questionnaire/specifications-completes.csv" "anssi-nis2-api/dist/anssi-nis2-api/src/adaptateurs"
+postdeploy: npx knex migrate:latest --knexfile anssi-nis2-api/knexfile.ts

--- a/anssi-nis2-api/package.json
+++ b/anssi-nis2-api/package.json
@@ -9,6 +9,7 @@
     "build": "tsc --build",
     "prettier": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start:dev": "knex migrate:latest && cp \"../commun/core/src/Domain/Questionnaire/specifications-completes.csv\" ./dist/anssi-nis2-api/src/adaptateurs && concurrently \"tsc --watch\" \"nodemon dist/anssi-nis2-api/src/main\"",
+    "prestart:prod": "cp \"../commun/core/src/Domain/Questionnaire/specifications-completes.csv\" ./dist/anssi-nis2-api/src/adaptateurs",
     "start:prod": "node dist/anssi-nis2-api/src/main",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
Le mettre en `postdeploy` ne fonctionne pas puisque la copie du CSV est un prérequis au démarrage de l'API. Sans le CSV, l'API crashe au démarrage.

On utilise le `pre / post` hook de npm : https://docs.npmjs.com/cli/v10/using-npm/scripts#pre--post-scripts