### PR TITLE
Ajout de la Console d'administration

### DIFF
--- a/anssi-nis2-api/migrations/20241017145009_simulateurReponseEnVraiJson.ts
+++ b/anssi-nis2-api/migrations/20241017145009_simulateurReponseEnVraiJson.ts
@@ -1,0 +1,13 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("simulateur_reponse", (t) => {
+    t.jsonb("reponseJson").alter();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("simulateur_reponse", (t) => {
+    t.text("reponseJson").alter();
+  });
+}

--- a/anssi-nis2-api/src/consoleAdministration.ts
+++ b/anssi-nis2-api/src/consoleAdministration.ts
@@ -1,0 +1,34 @@
+import * as Knex from "knex";
+import * as configurationKnex from "../knexfile";
+import { AdaptateurJournalPostgres } from "./adaptateurs/adaptateurJournal.postgres";
+import { AdaptateurEligibiliteCsv } from "./adaptateurs/adaptateurEligibilite.csv";
+
+export class ConsoleAdministration {
+  constructor(
+    private readonly adaptateurJournal = new AdaptateurJournalPostgres(),
+    private readonly adaptateurEligibilite = new AdaptateurEligibiliteCsv(),
+    private readonly knexPersistance: Knex.Knex = Knex(configurationKnex),
+  ) {}
+
+  public async genereTousEvenementsQuestionnaire() {
+    const reponses = await this.knexPersistance("simulateur_reponse").select();
+
+    const succes = [];
+    const erreurs = [];
+
+    reponses.map(({ id, reponseJson }) => {
+      try {
+        const resultat =
+          this.adaptateurEligibilite.evalueEligibilite(reponseJson);
+        succes.push(resultat);
+      } catch (e) {
+        erreurs.push({ erreur: e, id: id });
+      }
+    });
+
+    console.log(erreurs);
+
+    console.log("-----------");
+    console.log(`RÉSUMÉ : ✅ ${succes.length}. 💥 ${erreurs.length}.`);
+  }
+}


### PR DESCRIPTION
Cette PR ajoute une console d'administration qui va nous permettre de réaliser des actions d'admin.

La première sera la regénération de tous les événements Metabase, pour qu'ils incluent le résultat du test d'éligibilité.

Pour l'instant la console fait du log, pour prendre un peu la température de ce rattrapage de données Metabase.