### PR TITLE
Changement dans l'accès au CSV

### DIFF
--- a/anssi-nis2-api/package.json
+++ b/anssi-nis2-api/package.json
@@ -8,8 +8,7 @@
   "scripts": {
     "build": "tsc --build",
     "prettier": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start:dev": "knex migrate:latest && cp \"../commun/core/src/Domain/Questionnaire/specifications-completes.csv\" ./dist/anssi-nis2-api/src/adaptateurs && concurrently \"tsc --watch\" \"nodemon dist/anssi-nis2-api/src/main\"",
-    "prestart:prod": "cp \"../commun/core/src/Domain/Questionnaire/specifications-completes.csv\" ./dist/anssi-nis2-api/src/adaptateurs",
+    "start:dev": "knex migrate:latest && concurrently \"tsc --watch\" \"nodemon dist/anssi-nis2-api/src/main\"",
     "start:prod": "node dist/anssi-nis2-api/src/main",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/anssi-nis2-api/src/adaptateurs/adaptateurEligibilite.csv.ts
+++ b/anssi-nis2-api/src/adaptateurs/adaptateurEligibilite.csv.ts
@@ -5,22 +5,25 @@ import {
   ReponsesEtResultatAvecAnalyse,
 } from "./adaptateurEligibilite";
 import { evalueEligibilite } from "../../../commun/core/src/Domain/Questionnaire/evalueEligibilite";
+import * as path from "node:path";
 
 export class AdaptateurEligibiliteCsv implements AdaptateurEligibilite {
   private readonly contenuDuCsv: string;
 
   constructor() {
-    // C'est le process de build copie le .csv dans le répertoire de cet adaptateur
-    const path = __dirname + "/specifications-completes.csv";
+    // On remonte 5 fois, car on navigue depuis `dist/…`
+    const csv = path.normalize(
+      `${__dirname}/../../../../../commun/core/src/Domain/Questionnaire/specifications-completes.csv`,
+    );
 
-    const csvIntrouvable = !fs.existsSync(path);
+    const csvIntrouvable = !fs.existsSync(csv);
     if (csvIntrouvable) {
       throw new Error(
-        `Impossible de trouver le CSV de spécifications. Chemin : "${path}".`,
+        `Impossible de trouver le CSV de spécifications. Chemin : "${csv}".`,
       );
     }
 
-    this.contenuDuCsv = fs.readFileSync(path).toString("utf-8");
+    this.contenuDuCsv = fs.readFileSync(csv).toString("utf-8");
   }
 
   evalueEligibilite(

--- a/anssi-nis2-api/src/consoleAdministration.ts
+++ b/anssi-nis2-api/src/consoleAdministration.ts
@@ -3,7 +3,7 @@ import * as configurationKnex from "../knexfile";
 import { AdaptateurJournalPostgres } from "./adaptateurs/adaptateurJournal.postgres";
 import { AdaptateurEligibiliteCsv } from "./adaptateurs/adaptateurEligibilite.csv";
 
-export class ConsoleAdministration {
+export default class ConsoleAdministration {
   constructor(
     private readonly adaptateurJournal = new AdaptateurJournalPostgres(),
     private readonly adaptateurEligibilite = new AdaptateurEligibiliteCsv(),


### PR DESCRIPTION
On change la façon d'accéder au CSV pour qu'il fonctionne quel que soit le mode d'exécution : _runtime_  ou bien dans un process `node` déclenché sur le PaaS.