### PR TITLE
[CLEVER] Déclenche le build dans le script npm `install`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,6 +28,3 @@ jobs:
 
       - name: Lancement des tests unitaires
         run: npm test
-
-      - name: Construction des applications
-        run: npm run build --if-present

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint \"./anssi-nis2-*/{src,apps,libs,test}/**/*.ts\" --fix",
     "prettier": "npm run prettier --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
+    "install": "npm run build --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
     "start": "npm run start:prod -w anssi-nis2-api",
     "prepare": "husky install"


### PR DESCRIPTION
Selon la documentation Clever, `npm install` doit déclencher le build de l'application.

https://developers.clever-cloud.com/doc/applications/javascript/nodejs/#custom-build-phase