### PR TITLE
modifie le lien contact du centre d'aide

### DIFF
--- a/anssi-nis2-ui/src/Components/BOM/BOM.tsx
+++ b/anssi-nis2-ui/src/Components/BOM/BOM.tsx
@@ -6,8 +6,8 @@ export const BOM: DefaultComponent = () => {
       nomService="MonEspaceNIS2"
       liens={JSON.stringify([
         {
-          texte: "💬 Nous contacter par chat",
-          href: "https://aide.monespacenis2.cyber.gouv.fr/",
+          texte: "💬 Nous contacter",
+          href: "https://aide.monespacenis2.cyber.gouv.fr/fr/article/nous-contacter-1mvyy9f/",
         },
         {
           texte: "🙌 Consulter la FAQ",


### PR DESCRIPTION
On a désactivé le chat en ligne car personne s'en occupait donc j'ai modifié dans le centre d'aide le wording de la phrase et j'ai enlevé "par chat" + j'ai modifié le lien qui redirige désormais vers une FAQ