### PR TITLE
[npm] Passe à Storybook 9.1.17

### DIFF
--- a/anssi-nis2-ui/package.json
+++ b/anssi-nis2-ui/package.json
@@ -54,7 +54,7 @@
     "jsdom": "^22.1.0",
     "prettier": "3.0.3",
     "sass": "^1.72.0",
-    "storybook": "^9.1.10",
+    "storybook": "^9.1.17",
     "typescript": "^5.1.6",
     "vite": "^6.4.1",
     "vitest": "^3.2.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
-        "eslint-plugin-storybook": "^9.1.10",
+        "eslint-plugin-storybook": "^9.1.17",
         "husky": "^8.0.0",
         "lint-staged": "^15.5.2",
         "sass": "^1.72.0",
@@ -328,7 +328,7 @@
         "jsdom": "^22.1.0",
         "prettier": "3.0.3",
         "sass": "^1.72.0",
-        "storybook": "^9.1.10",
+        "storybook": "^9.1.17",
         "typescript": "^5.1.6",
         "vite": "^6.4.1",
         "vitest": "^3.2.4"
@@ -6856,9 +6856,9 @@
       }
     },
     "node_modules/eslint-plugin-storybook": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-9.1.10.tgz",
-      "integrity": "sha512-HAVQ9HTMydcFj5KjnzsETOwPe19eIViwRBhc47lvU04YEFTgEg2rlXN1xozxHUlQ+XkkoKYkIUYoqo7KgGhkIA==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-9.1.17.tgz",
+      "integrity": "sha512-7Qn3XxXdWLAt6arSH8Tt8Su/fAAqA+d5Oc51g7ubOE5Yfc5x0dMIgCfCG5RrIjt0RDRpwp4n194Mge+sAA3WMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6869,7 +6869,7 @@
       },
       "peerDependencies": {
         "eslint": ">=8",
-        "storybook": "^9.1.10"
+        "storybook": "^9.1.17"
       }
     },
     "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/scope-manager": {
@@ -13645,9 +13645,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.10.tgz",
-      "integrity": "sha512-4+U7gF9hMpGilQmdVJwQaVZZEkD7XwC4ZDmBa51mobaPYelELEMoMfNM2hLyvB2x12gk1IJui1DnwOE4t+MXhw==",
+      "version": "9.1.17",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
+      "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
-    "eslint-plugin-storybook": "^9.1.10",
+    "eslint-plugin-storybook": "^9.1.17",
     "husky": "^8.0.0",
     "lint-staged": "^15.5.2",
     "sass": "^1.72.0",


### PR DESCRIPTION
… pour supprimer [l'alerte dependabot 93](https://github.com/betagouv/anssi-nis2/security/dependabot/93).

D'après mes tests, Storybook se lance toujours correctement en local.