### PR TITLE
Supprime la configuration `trustProxy` inutile

### DIFF
--- a/anssi-nis2-api/src/serveur.express.ts
+++ b/anssi-nis2-api/src/serveur.express.ts
@@ -16,7 +16,6 @@ export async function creeServeurExpress(
   dependances.adaptateurGestionErreur.initialise(app);
   dependances.adaptateurProtection.initialise(app);
 
-  app.set("trust proxy", 1);
   app.disable("x-powered-by");
   activeFiltrageIp(app);
 


### PR DESCRIPTION
... En testant le filtrage IP et le rate-limit, on se rend compte que les deux mécanismes réimplémente leur propre extraction d'adresse Ip. 

Le paramètre de `trust proxy` est donc inutile.